### PR TITLE
Fix: TryCP tests running on targets

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -109,7 +109,7 @@ jobs:
           # Start a TryCP instance
           nix develop .#ci -c bash -c "source ./scripts/trycp.sh && start_trycp &"
 
-          RUST_LOG=info CONDUCTOR_CONFIG="CI" TRYCP_RUST_LOG="info" MIN_PEERS=2 nix run .#${{ matrix.scenario }} -- --targets targets.yaml --instances-per-target 2 --duration 120 --no-progress --reporter influx-file ${{ matrix.extra-args }} > >(tee logs/scenario-stdout.log) 2> >(tee logs/scenario-stderr.log >&2)
+          RUST_LOG=info TRYCP_RUST_LOG="info" MIN_PEERS=2 nix run .#${{ matrix.scenario }} -- --targets targets.yaml --instances-per-target 2 --duration 120 --no-progress --reporter influx-file ${{ matrix.extra-args }} > >(tee logs/scenario-stdout.log) 2> >(tee logs/scenario-stderr.log >&2)
 
           # Stop the TryCP instance
           nix develop .#ci -c bash -c "source ./scripts/trycp.sh && stop_trycp"

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -109,7 +109,7 @@ jobs:
           # Start a TryCP instance
           nix develop .#ci -c bash -c "source ./scripts/trycp.sh && start_trycp &"
 
-          RUST_LOG=info CONDUCTOR_CONFIG="CI" TRYCP_RUST_LOG="info" MIN_PEERS=2 nix run .#${{ matrix.scenario }} -- --targets targets-ci.yaml --instances-per-target 2 --duration 120 --no-progress --reporter influx-file ${{ matrix.extra-args }} > >(tee logs/scenario-stdout.log) 2> >(tee logs/scenario-stderr.log >&2)
+          RUST_LOG=info CONDUCTOR_CONFIG="CI" TRYCP_RUST_LOG="info" MIN_PEERS=2 nix run .#${{ matrix.scenario }} -- --targets targets.yaml --instances-per-target 2 --duration 120 --no-progress --reporter influx-file ${{ matrix.extra-args }} > >(tee logs/scenario-stdout.log) 2> >(tee logs/scenario-stderr.log >&2)
 
           # Stop the TryCP instance
           nix develop .#ci -c bash -c "source ./scripts/trycp.sh && stop_trycp"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   broadcast channel that it uses internally. Shutdown failures used to panic but it a `ShutdownHandle` happens to not
   have any subscribers then that should not be considered a fatal error. It will now log a warning instead.
 - Metrics now automatically include `run_id` and `scenario_name` tags.
+- Update `trycp_client` and `trycp_api` dependencies to `v0.17.0-dev.6`. [#117](https://github.com/holochain/wind-tunnel/pull/117)
 
 ### Deprecated
 ### Removed
 ### Fixed
+- Run the TryCP scenarios in the [Performance Workflow](.github/workflows/performance.yaml) on the Holo Ports defined in [targets.yaml](targets.yaml). [#117](https://github.com/holochain/wind-tunnel/pull/117)
+
 ### Security
 
 ## [0.2.0-alpha.2] - 2024-05-25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,9 +4821,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trycp_api"
-version = "0.17.0-dev.5"
+version = "0.17.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e53225447beff00bfa5d9269d0c320a8c66e221952ed4d9b954c2312291a6b"
+checksum = "8c7767c7f3f9d92c6cedff9d7d5345914ed357200b111fc0eb673250ec8514a8"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -4832,9 +4832,9 @@ dependencies = [
 
 [[package]]
 name = "trycp_client"
-version = "0.17.0-dev.5"
+version = "0.17.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ae49f96fcf3a0a93518deff6cd13f503c998d65167f49ee91c05d73c683659"
+checksum = "8ef49152101b907dfbc7a694b226f533cd65751deac93cce1f319d68c35435ec"
 dependencies = [
  "futures",
  "rmp-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,8 +95,8 @@ ed25519-dalek = "2.1"
 
 # Deps for Holochain
 holochain_client = { version = "=0.6.0-dev.10" }
-trycp_client = { version = "0.17.0-dev.5" }
-trycp_api = { version = "0.17.0-dev.5" }
+trycp_client = { version = "0.17.0-dev.6" }
+trycp_api = { version = "0.17.0-dev.6" }
 holochain_zome_types = { version = "0.4.0-dev.18" }
 holo_hash = { version = "0.4.0-dev.13" }
 holochain_types = { version = "0.4.0-dev.26" }

--- a/bindings/trycp_runner/src/common.rs
+++ b/bindings/trycp_runner/src/common.rs
@@ -330,7 +330,6 @@ where
     std::fs::create_dir_all(&path)
         .with_context(|| format!("Failed to create log directory at {path:?}"))?;
 
-    std::fs::write(path.join("lair-stderr.log"), logs.lair_stderr)?;
     std::fs::write(path.join("conductor-stdout.log"), logs.conductor_stdout)?;
     std::fs::write(path.join("conductor-stderr.log"), logs.conductor_stderr)?;
 

--- a/flake.lock
+++ b/flake.lock
@@ -275,16 +275,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1723577336,
-        "narHash": "sha256-Gx9VOm1/LKwJfhSbe6uMG8h2vyKaMPoiz4ACWqOb+1o=",
+        "lastModified": 1727873905,
+        "narHash": "sha256-0Dn/1FzO2/QqUt30KY8EKRjmcqIS1WjtrfmAQXkIgQE=",
         "owner": "holochain",
         "repo": "tryorama",
-        "rev": "9fd4f50cbd5863bc5708749aaa341c859db48c40",
+        "rev": "fda086208f71f10a5cfd3c962cb59abac966afba",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.17.0-dev.5",
+        "ref": "v0.17.0-dev.6",
         "repo": "tryorama",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
     };
 
     tryorama = {
-      url = "github:holochain/tryorama?ref=v0.17.0-dev.5";
+      url = "github:holochain/tryorama?ref=v0.17.0-dev.6";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         crane.follows = "crane";


### PR DESCRIPTION
This PR makes it so that the TryCP test scenarios in the `Performance` workflow are actually run on the targets defined in `targets.yaml` as they should be.

It also updates `trycp_client` and `trycp_api` versions to `0.17.0-dev.6` to use the `lair-keystore` in-process instead of the binary as there is an issue with getting the connection URL from the binary (see holochain/lair#137).

### TODO
- [x] Update changelog