### PR TITLE
fix: correct scenario name in performance workflow

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         # To run a test with TryCP and default configuration, add the scenario name to this array.
-        scenario: [trycp_write_validated, remote_call_rate, validation_receipts, remote_signal_scenario]
+        scenario: [trycp_write_validated, remote_call_rate, validation_receipts, remote_signals]
         # To run a test with TryCP and additional configuration, add the scenario name and `extra-args` as an `include` item.
         include:
           - scenario: two_party_countersigning


### PR DESCRIPTION
Whilst trying to run the Performance workflow I saw that the new scenario name is wrong. This PR fixes that.

See the failed run: https://github.com/holochain/wind-tunnel/actions/runs/11503359238/job/32020459282

And now it passes: https://github.com/holochain/wind-tunnel/actions/runs/11515479950