### PR TITLE
chore: Update Docker Compose deploy to use restart always

### DIFF
--- a/influx/docker-compose.yaml
+++ b/influx/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
     image: caddy:2.8
     depends_on:
       - influxdb
-    restart: on-failure
+    restart: always
     command:
       - caddy
       - reverse-proxy


### PR DESCRIPTION
There was a problem where this was deployed. After a machine restart, the influx container would come back up but caddy would fail to start up. This should sort that out so that caddy will try to keep itself up.