### PR TITLE
chore: follow conventional commits for actions

### DIFF
--- a/.github/workflows/cargo_update.yaml
+++ b/.github/workflows/cargo_update.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "Update Cargo.lock"
-          title: "Update Cargo.lock"
+          commit-message: "chore: update Cargo.lock file"
+          title: "chore: update Cargo.lock file"
           body: "This PR updates the Cargo.lock file."
           branch: "update-cargo-lock"
           branch-suffix: "short-commit-hash"

--- a/.github/workflows/flake_update.yaml
+++ b/.github/workflows/flake_update.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "Update flake.lock"
-          title: "Update flake.lock"
+          commit-message: "chore: update flake.lock file"
+          title: "chore: update flake.lock file"
           body: "This PR updates the flake.lock file."
           branch: "update-flake-lock"
           branch-suffix: "short-commit-hash"


### PR DESCRIPTION
In the hopes of making progress on the release automation stuff, I enabled the [Cocogitto bot](https://github.com/apps/cocogitto-bot) in this repository which will check that all commits in a PR follow the conventional commit style. Therefore, this PR updates the commit messages (and PR titles) of the automated workflows used to perform cargo and flake updates. 