### PR TITLE
feat: add kitsune binding & sample scenario

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,10 +26,10 @@ jobs:
         if: runner.os == 'Linux'
         uses: AdityaGarg8/remove-unwanted-software@v2
         with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-codeql: "true"
+          remove-docker-images: "true"
 
       - name: Install nix
         uses: cachix/install-nix-action@v30
@@ -69,14 +69,18 @@ jobs:
         run: |
           nix develop .#ci -c bash -c "source ./scripts/checks.sh && check_rust_fmt"
 
-      - name: Build and unit tests
-        run: |
-          nix build .#workspace
-
       - name: Lint Rust
         run: |
           # Currently the only check is clippy, could bundle the other checks into the flake and remove the steps above?
           nix flake check --all-systems
+
+      - name: Run unit tests
+        run: |
+          nix develop .#ci -c bash -c "cargo test --workspace --all-targets"
+
+      - name: Build
+        run: |
+          nix build .#workspace
 
       - name: Smoke test - zome_call_single_value
         run: |
@@ -250,6 +254,19 @@ jobs:
           nix develop .#ci -c bash -c "source ./scripts/trycp.sh && stop_trycp"
           # Stop local network services
           pkill hc-run-local
+
+      - name: Smoke test - kitsune continuous flow
+        run: |
+          set -x
+
+          # Start local bootstrap and signal server
+          nix develop .#ci -c bash -c "kitsune2-bootstrap-srv --listen 127.0.0.1:30000 &"
+
+          # Run the scenario
+          RUST_LOG=warn cargo run -p kitsune_continuous_flow -- --bootstrap-server-url http://127.0.0.1:30000 --signal-server-url ws://127.0.0.1:30000 --duration 15 --agents 2
+
+          # Stop servers
+          pkill kitsune2-bootst
 
       - name: Build scenario bundles
         if: runner.os == 'Linux'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "argminmax"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +202,18 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "async-trait"
@@ -259,6 +277,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4e8200b9a4a5801a769d50eeabc05670fec7e959a8cb7a63a93e4e519942ae"
+dependencies = [
+ "aws-lc-sys",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "paste",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sha1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56bac90848f6a9393ac03c63c640925c4b7c8ca21654de40d53f55964667c7d8"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.23.23",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower 0.4.13",
+ "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +438,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.99",
+ "which 4.4.2",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +489,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit_field"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -411,6 +571,9 @@ name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "callback"
@@ -449,6 +612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +631,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -498,6 +676,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +721,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
+ "terminal_size",
 ]
 
 [[package]]
@@ -551,6 +741,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -592,6 +791,15 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -664,6 +872,32 @@ version = "0.1.0"
 dependencies = [
  "hdi",
  "serde",
+]
+
+[[package]]
+name = "cpp_build"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f8638c97fbd79cc6fc80b616e0e74b49bac21014faed590bbc89b7e2676c90"
+dependencies = [
+ "cc",
+ "cpp_common",
+ "lazy_static",
+ "proc-macro2",
+ "regex",
+ "syn 2.0.99",
+ "unicode-xid",
+]
+
+[[package]]
+name = "cpp_common"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fcfea2ee05889597d35e986c2ad0169694320ae5cc8f6d2640a4bb8a884560"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -774,6 +1008,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -898,6 +1142,33 @@ name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+
+[[package]]
+name = "datachannel"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9104be65808f5ba4cae77831aa5b1874a64de31ceed449db37897910d0d72e"
+dependencies = [
+ "datachannel-sys",
+ "derivative",
+ "parking_lot 0.12.3",
+ "serde",
+ "tracing",
+ "webrtc-sdp",
+]
+
+[[package]]
+name = "datachannel-sys"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ead19df10c4e46d8d4b33de06c6224dcafc98bad666ac62629d363675866cae"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "cpp_build",
+ "once_cell",
+ "openssl-src",
+]
 
 [[package]]
 name = "der"
@@ -1178,6 +1449,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1593,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1477,6 +1775,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,7 +1843,7 @@ dependencies = [
  "serde_yaml",
  "toml",
  "walkdir",
- "which",
+ "which 7.0.2",
 ]
 
 [[package]]
@@ -1597,7 +1907,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_bytes",
- "sodoken",
+ "sodoken 0.0.11",
 ]
 
 [[package]]
@@ -1835,7 +2145,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "shrinkwraprs",
- "sodoken",
+ "sodoken 0.0.11",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -1925,7 +2235,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shrinkwraprs",
- "sodoken",
+ "sodoken 0.0.11",
  "sqlformat",
  "tempfile",
  "thiserror 1.0.69",
@@ -2051,7 +2361,7 @@ dependencies = [
  "futures",
  "once_cell",
  "rpassword",
- "sodoken",
+ "sodoken 0.0.11",
  "tokio",
 ]
 
@@ -2094,7 +2404,7 @@ dependencies = [
  "serde_bytes",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tracing",
 ]
 
@@ -2260,6 +2570,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2579,6 +2890,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5db78961ebb97b6d16ba61a65b38978a67cf7efaa91903c500b4771d1920d00"
 
 [[package]]
+name = "influxive-otel-atomic-obs"
+version = "0.0.2-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac0ec101d28862a46c15d6140cec376b02725160dfcf57282952898a94cf35e"
+dependencies = [
+ "opentelemetry_api",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,6 +3022,172 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune2"
+version = "0.0.1-alpha6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31cf0f3da7d1d57ade137fc5dca894549b51b279d236555f0311769333cf1656"
+dependencies = [
+ "bytes",
+ "kitsune2_api",
+ "kitsune2_core",
+ "kitsune2_gossip",
+ "kitsune2_transport_tx5",
+]
+
+[[package]]
+name = "kitsune2_api"
+version = "0.0.1-alpha6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da6996933613a9964fca94803e96e728f8fa2ff3f3f427da64f8a4cfff56ce2b"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "prost",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "kitsune2_bootstrap_client"
+version = "0.0.1-alpha6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380efb6d4a39fc866e334e5302f5b6e9b0aecb426f6f8b079fcd785fc8fa2887"
+dependencies = [
+ "kitsune2_api",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "kitsune2_bootstrap_srv"
+version = "0.0.1-alpha6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e81ba8f9903f86a1363e2c9be70b3b3c2e719218d32d9b0f9e93b45f74fa80cd"
+dependencies = [
+ "async-channel",
+ "axum",
+ "axum-server",
+ "base64 0.22.1",
+ "bytes",
+ "clap 4.5.31",
+ "ctrlc",
+ "ed25519-dalek",
+ "futures",
+ "num_cpus",
+ "rustls 0.23.23",
+ "sbd-server",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "kitsune2_core"
+version = "0.0.1-alpha6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f527d87c1733c5322bb9eeadab10d472e277cab11fe138679a2b2f52cb08f76"
+dependencies = [
+ "backon",
+ "bytes",
+ "ed25519-dalek",
+ "futures",
+ "kitsune2_api",
+ "kitsune2_bootstrap_client",
+ "prost",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "ureq",
+ "url",
+]
+
+[[package]]
+name = "kitsune2_dht"
+version = "0.0.1-alpha6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc66579332a282d8ec3d132372b1e461524967013117f89e1d3ce8410a6fd1d"
+dependencies = [
+ "bytes",
+ "kitsune2_api",
+ "tracing",
+]
+
+[[package]]
+name = "kitsune2_gossip"
+version = "0.0.1-alpha6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "441f0ed6f364e52f3cfa25097379ab62cb2081f39e7b175a667388386c840648"
+dependencies = [
+ "bytes",
+ "kitsune2_api",
+ "kitsune2_core",
+ "kitsune2_dht",
+ "prost",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "kitsune2_transport_tx5"
+version = "0.0.1-alpha6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80594415d628d26a4ba6d9057f18272309fab7d8c9895c51eb865729d04a6ad3"
+dependencies = [
+ "bytes",
+ "kitsune2_api",
+ "serde",
+ "tokio",
+ "tracing",
+ "tx5",
+]
+
+[[package]]
+name = "kitsune_client_instrumented"
+version = "0.4.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "env_logger",
+ "kitsune2",
+ "kitsune2_api",
+ "kitsune2_bootstrap_srv",
+ "kitsune2_core",
+ "kitsune2_gossip",
+ "kitsune2_transport_tx5",
+ "log",
+ "serde",
+ "serde_json",
+ "sha3",
+ "tokio",
+ "wind_tunnel_core",
+ "wind_tunnel_instruments",
+ "wind_tunnel_instruments_derive",
+]
+
+[[package]]
+name = "kitsune_continuous_flow"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "kitsune_wind_tunnel_runner",
+ "tokio",
+]
+
+[[package]]
 name = "kitsune_p2p_bin_data"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,6 +3303,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune_wind_tunnel_runner"
+version = "0.4.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "clap 4.5.31",
+ "env_logger",
+ "kitsune_client_instrumented",
+ "log",
+ "serde",
+ "serde_json",
+ "sha3",
+ "tokio",
+ "wind_tunnel_runner",
+]
+
+[[package]]
 name = "lair_keystore"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +3374,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical-core"
@@ -2964,6 +3473,16 @@ dependencies = [
  "core2",
  "hashbrown 0.14.5",
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3092,6 +3611,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
@@ -3259,6 +3784,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3503,6 +4040,12 @@ dependencies = [
  "fnv",
  "unicode-width 0.2.0",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4161,6 +4704,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ccf34da56fc294e7d4ccf69a85992b7dfb826b7cf57bac6a70bba3494cc08a"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4250,6 +4803,29 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
@@ -4421,9 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.5.0"
+version = "11.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -4669,7 +5245,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -4708,7 +5284,7 @@ dependencies = [
  "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
- "tower",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4844,6 +5420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4879,15 +5461,45 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
- "once_cell",
+ "log",
+ "ring 0.17.11",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring 0.17.11",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4930,6 +5542,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.11",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -4975,6 +5588,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sbd-client"
+version = "0.0.9-alpha2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc6dac7ad1a4e0001865290c3bcf430bbbc8e238e759f9fdc51deffdb1cf918"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "futures",
+ "rand 0.8.5",
+ "rustls 0.22.4",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tokio-tungstenite 0.21.0",
+ "tracing",
+ "webpki-roots 0.26.8",
+]
+
+[[package]]
+name = "sbd-e2e-crypto-client"
+version = "0.0.9-alpha2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b3f2616dad53cbe25ba970243bdad92aadb37fec2caeb91462c40900f75448"
+dependencies = [
+ "bytes",
+ "sbd-client",
+ "sodoken 0.0.901-alpha",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sbd-server"
+version = "0.0.10-alpha2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4b26ba9214bd74c44b21b0c79dbb78ee291d0d964f035da97634acb8a55105"
+dependencies = [
+ "anstyle",
+ "base64 0.22.1",
+ "bytes",
+ "clap 4.5.31",
+ "ed25519-dalek",
+ "futures",
+ "rand 0.8.5",
+ "rustls 0.23.23",
+ "rustls-pemfile 2.2.0",
+ "slab",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-tungstenite 0.23.1",
 ]
 
 [[package]]
@@ -5337,6 +6003,16 @@ dependencies = [
  "one_err",
  "parking_lot 0.12.3",
  "tokio",
+]
+
+[[package]]
+name = "sodoken"
+version = "0.0.901-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888b6eb6ff4b987cd894f90d396562c9f332dfa3ab27a00c9cbc798d2f402037"
+dependencies = [
+ "libc",
+ "libsodium-sys-stable",
 ]
 
 [[package]]
@@ -5713,6 +6389,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5880,6 +6566,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
@@ -5896,8 +6593,35 @@ checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "tokio",
- "tungstenite",
+ "tokio-rustls 0.25.0",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.23.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -5949,6 +6673,21 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -5980,6 +6719,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6102,7 +6842,7 @@ dependencies = [
  "rmp-serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "trycp_api",
 ]
 
@@ -6123,7 +6863,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "trycp_api",
  "trycp_client",
  "url",
@@ -6197,9 +6937,47 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.2.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.2.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -6216,6 +6994,70 @@ dependencies = [
  "rmp-serde",
  "tokio",
  "trycp_wind_tunnel_runner",
+]
+
+[[package]]
+name = "tx5"
+version = "0.3.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ff22ef7eda26341ec67a6249ea5b002bafeeda7fd79220d19ab115811af29e"
+dependencies = [
+ "base64 0.22.1",
+ "futures",
+ "influxive-otel-atomic-obs",
+ "serde",
+ "slab",
+ "tokio",
+ "tracing",
+ "tx5-connection",
+ "tx5-core",
+ "url",
+]
+
+[[package]]
+name = "tx5-connection"
+version = "0.3.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22df1f226f5aa9a555a96a8baafd8f7309dc42d9b740dca58e2c4dcd1da0cf9c"
+dependencies = [
+ "bit_field",
+ "datachannel",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tx5-core",
+ "tx5-signal",
+]
+
+[[package]]
+name = "tx5-core"
+version = "0.3.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0972fe9c248a645c6d9cf2a1993718775d5c5c910181032197577d7084a6a943"
+dependencies = [
+ "base64 0.22.1",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "tx5-signal"
+version = "0.3.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccd01421392bf92637059b6caa782c301e6ad47794564708827c9eb7bb8187f"
+dependencies = [
+ "rand 0.8.5",
+ "sbd-e2e-crypto-client",
+ "tokio",
+ "tracing",
+ "tx5-core",
 ]
 
 [[package]]
@@ -6300,9 +7142,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64 0.22.1",
+ "flate2",
  "log",
  "once_cell",
+ "rustls 0.23.23",
+ "rustls-pki-types",
  "url",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -6601,6 +7447,37 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webrtc-sdp"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a87d58624aae43577604ea137de9dcaf92793eccc4d816efad482001c2e055ca"
+dependencies = [
+ "log",
+ "url",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ members = [
 
   "bindings/client",
   "bindings/runner",
+  "bindings/kitsune_client",
+  "bindings/kitsune_runner",
   "bindings/trycp_client",
   "bindings/trycp_runner",
 
@@ -30,6 +32,7 @@ members = [
   "scenarios/write_validated",
   "scenarios/trycp_write_validated",
   "scenarios/validation_receipts",
+  "scenarios/kitsune_continuous_flow",
 
   "zomes/return_single_value/coordinator",
   "zomes/crud/coordinator",
@@ -61,6 +64,8 @@ default-members = [
 
   "bindings/client",
   "bindings/runner",
+  "bindings/kitsune_client",
+  "bindings/kitsune_runner",
   "bindings/trycp_client",
   "bindings/trycp_runner",
 
@@ -71,6 +76,7 @@ default-members = [
 
 [workspace.dependencies]
 anyhow = "1.0.80"
+bytes = "1.10"
 clap = { version = "4.5.1", features = ["derive"] }
 tokio = { version = "1.36.0", features = ["full"] }
 parking_lot = "0.12.1"
@@ -131,6 +137,13 @@ hdk = { version = "0.4.0", features = [
 hdi = { version = "0.5.0", features = ["unstable-functions"] }
 holochain_serialized_bytes = "0.0.55"
 
+# Deps for Kitsune
+kitsune2 = "0.0.1-alpha6"
+kitsune2_api = "0.0.1-alpha6"
+kitsune2_core = "0.0.1-alpha6"
+kitsune2_gossip = "0.0.1-alpha6"
+kitsune2_transport_tx5 = { version = "0.0.1-alpha6", default-features = false }
+
 # Framework
 wind_tunnel_core = { path = "./framework/core", version = "0.4.0-alpha.1" }
 wind_tunnel_instruments = { path = "./framework/instruments", version = "0.4.0-alpha.1" }
@@ -141,13 +154,15 @@ wind_tunnel_summary_model = { path = "./framework/summary_model", version = "0.4
 # Bindings
 holochain_client_instrumented = { path = "./bindings/client", version = "0.4.0-alpha.1" }
 holochain_wind_tunnel_runner = { path = "./bindings/runner", version = "0.4.0-alpha.1" }
+kitsune_client_instrumented = { path = "./bindings/kitsune_client", version = "0.4.0-alpha.1" }
+kitsune_wind_tunnel_runner = { path = "./bindings/kitsune_runner", version = "0.4.0-alpha.1" }
 trycp_client_instrumented = { path = "./bindings/trycp_client", version = "0.4.0-alpha.1" }
 trycp_wind_tunnel_runner = { path = "./bindings/trycp_runner", version = "0.4.0-alpha.1" }
 
 # hApp Builder
 happ_builder = { path = "./happ_builder", version = "0.1.0" }
 
-# Zomes for coorindator dependencies
+# Zomes for coordinator dependencies
 crud_integrity = { path = "./zomes/crud/integrity" }
 timed_integrity = { path = "./zomes/timed/integrity" }
 callback_integrity = { path = "./zomes/callback/integrity" }

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ It is divided into the following crates:
 
 #### Holochain Bindings for Wind Tunnel
 
-The `bindings`, found in the `./bindings`, customise the `wind-tunnel` framework to Holochain. They are what you would be
+The `bindings`, found in `./bindings`, customise the `wind-tunnel` framework to Holochain. They are what you would be
 consuming when using `wind-tunnel` to test Holochain.
 
-The bindings contains the following crates:
+The bindings contain the following crates:
 - `holochain_client_instrumented`: A wrapper around the [`holochain_client`](https://crates.io/crates/holochain_client) that uses `instruments` and `instruments_derive`
   to instrument the client. It exports an API that is nearly identical to the `holochain_client` crate, except that when constructing client connections
   you need to provide a reporter which it can write results to.
@@ -333,7 +333,7 @@ For standard Wind Tunnel tests - start a sandbox for testing:
 hc s clean && echo "1234" | hc s --piped create && echo "1234" | hc s --piped -f 8888 run
 ```
 
-It is recommended to stop and start this sandbox conductor between test runs because getting Holochain back to a clean
+It is recommended to stop and start this sandbox conductor between test runs, because getting Holochain back to a clean state
 through its API is not yet implemented.
 
 You can then start a second terminal and run one of the scenarios in the `scenarios` directory:

--- a/bindings/kitsune_client/Cargo.toml
+++ b/bindings/kitsune_client/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "kitsune_client_instrumented"
+version = "0.4.0-alpha.1"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+bytes = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha3 = { workspace = true }
+tokio = { workspace = true }
+
+kitsune2 = { workspace = true }
+kitsune2_api = { workspace = true }
+kitsune2_core = { workspace = true }
+kitsune2_gossip = { workspace = true }
+kitsune2_transport_tx5 = { workspace = true }
+
+wind_tunnel_core = { workspace = true }
+wind_tunnel_instruments = { workspace = true }
+wind_tunnel_instruments_derive = { workspace = true }
+
+[dev-dependencies]
+env_logger = { workspace = true }
+kitsune2_bootstrap_srv = "0.0.1-alpha6"
+
+[lints]
+workspace = true

--- a/bindings/kitsune_client/src/lib.rs
+++ b/bindings/kitsune_client/src/lib.rs
@@ -1,0 +1,324 @@
+use anyhow::Context;
+use bytes::Bytes;
+use kitsune2::default_builder;
+use kitsune2_api::{
+    BoxFut, Builder, DhtArc, DynKitsune, DynLocalAgent, DynSpace, DynSpaceHandler, K2Result,
+    KitsuneHandler, LocalAgent, OpId, SpaceHandler, SpaceId, StoredOp, Timestamp,
+};
+use kitsune2_core::{
+    factories::config::{CoreBootstrapConfig, CoreBootstrapModConfig},
+    Ed25519LocalAgent,
+};
+use kitsune2_gossip::{K2GossipConfig, K2GossipModConfig};
+use kitsune2_transport_tx5::config::{Tx5TransportConfig, Tx5TransportModConfig};
+use op_store::{DynWtOpStore, WtOp, WtOpStore, WtOpStoreFactory};
+use std::{sync::Arc, time::Duration};
+use tokio::sync::Mutex;
+use wind_tunnel_instruments::prelude::{ReportMetric, Reporter};
+use wind_tunnel_instruments_derive::wind_tunnel_instrument;
+
+mod op_store;
+
+#[derive(Debug)]
+struct WtSpaceHandler;
+impl SpaceHandler for WtSpaceHandler {}
+
+#[derive(Debug)]
+struct WtKitsuneHandler;
+impl KitsuneHandler for WtKitsuneHandler {
+    fn create_space(&self, _space: SpaceId) -> BoxFut<'_, K2Result<DynSpaceHandler>> {
+        let space_handler: DynSpaceHandler = Arc::new(WtSpaceHandler);
+        Box::pin(async move { Ok(space_handler) })
+    }
+}
+
+#[derive(Debug)]
+struct State {
+    agent: DynLocalAgent,
+    op_store: DynWtOpStore,
+    space: DynSpace,
+    _kitsune: DynKitsune,
+}
+
+/// A Kitsune2 app for running performance tests in WindTunnel.
+#[derive(Debug)]
+pub struct WtChatter {
+    state: Arc<Mutex<State>>,
+    reporter: Arc<Reporter>,
+}
+
+impl WtChatter {
+    /// Construct an instance.
+    pub async fn create(
+        bootstrap_server_url: &str,
+        signal_server_url: &str,
+        space_id: &str,
+        reporter: Arc<Reporter>,
+    ) -> anyhow::Result<Self> {
+        let agent = Arc::new(Ed25519LocalAgent::default());
+        agent.set_tgt_storage_arc_hint(DhtArc::FULL);
+        // Counter to common practice, an op store has to be created first and passed
+        // to the factory constructor, to keep a handle to the typed WtOpStore in the chatter
+        // instance. This store instance is also used to instantiate the dummy factory, which
+        // will simply return the same store at the time of calling it during space creation.
+        let op_store = Arc::new(WtOpStore::new(agent.agent().clone(), reporter.clone()));
+        let kitsune_builder = Builder {
+            op_store: Arc::new(WtOpStoreFactory::new(op_store.clone())),
+            ..default_builder()
+        }
+        .with_default_config()?;
+        kitsune_builder
+            .config
+            .set_module_config(&CoreBootstrapModConfig {
+                core_bootstrap: CoreBootstrapConfig {
+                    server_url: bootstrap_server_url.to_string(),
+                    ..Default::default()
+                },
+            })?;
+        kitsune_builder
+            .config
+            .set_module_config(&Tx5TransportModConfig {
+                tx5_transport: Tx5TransportConfig {
+                    server_url: signal_server_url.to_string(),
+                    signal_allow_plain_text: true,
+                    ..Default::default()
+                },
+            })?;
+        kitsune_builder
+            .config
+            .set_module_config(&K2GossipModConfig {
+                k2_gossip: K2GossipConfig {
+                    initiate_interval_ms: 1000,
+                    min_initiate_interval_ms: 900,
+                    ..Default::default()
+                },
+            })?;
+        let kitsune = kitsune_builder.build().await?;
+        kitsune.register_handler(Arc::new(WtKitsuneHandler)).await?;
+        // This will call the op store factory's `create` method.
+        let space = kitsune
+            .space(SpaceId::from(Bytes::copy_from_slice(space_id.as_bytes())))
+            .await?;
+
+        log::info!("created chatter with id {}", agent.agent());
+
+        let state = Arc::new(Mutex::new(State {
+            agent,
+            op_store,
+            space,
+            _kitsune: kitsune,
+        }));
+
+        Ok(Self { state, reporter })
+    }
+
+    /// Join the WindTunnel space.
+    #[wind_tunnel_instrument]
+    pub async fn join_space(&self) -> anyhow::Result<()> {
+        let state_lock = self.state.lock().await;
+        state_lock
+            .space
+            .local_agent_join(state_lock.agent.clone())
+            .await?;
+
+        // Wait for agent to publish their info to the bootstrap & peer store.
+        tokio::time::timeout(Duration::from_secs(20), async {
+            loop {
+                tokio::time::sleep(Duration::from_millis(1000)).await;
+                let maybe_agent = match state_lock
+                    .space
+                    .peer_store()
+                    .get(state_lock.agent.agent().clone())
+                    .await
+                {
+                    Ok(maybe_agent) => maybe_agent,
+                    Err(err) => {
+                        log::error!("failure to query peer store: {err}");
+                        continue;
+                    }
+                };
+                if maybe_agent.is_some() {
+                    break;
+                }
+            }
+        })
+        .await
+        .context("failure to join space")
+    }
+
+    /// Say a message, so that it will be gossiped to all peers.
+    #[wind_tunnel_instrument]
+    pub async fn say(&self, message: &str) -> anyhow::Result<Vec<OpId>> {
+        let state = self.state.lock().await;
+        let message_op = WtOp::new(Timestamp::now(), message.into());
+        let message_ids = state
+            .op_store
+            .store_op(message_op)
+            .await
+            .context("failure to write ops to the store")?;
+        state
+            .space
+            .inform_ops_stored(
+                message_ids
+                    .clone()
+                    .into_iter()
+                    .map(|message_id| StoredOp {
+                        created_at: Timestamp::now(),
+                        op_id: message_id,
+                    })
+                    .collect(),
+            )
+            .await?;
+        log::info!("agent {} said {}", state.agent.agent(), message);
+
+        self.reporter.add_custom(
+            ReportMetric::new("message said")
+                .with_tag("agent_id", state.agent.agent().to_string())
+                .with_field("message_said", message_ids.len() as u32),
+        );
+
+        Ok(message_ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kitsune2_bootstrap_srv::{BootstrapSrv, Config};
+    use std::time::{Duration, Instant};
+    use wind_tunnel_core::prelude::ShutdownHandle;
+    use wind_tunnel_instruments::{ReportConfig, Reporter};
+
+    pub(crate) fn test_reporter() -> Arc<Reporter> {
+        let runtime = tokio::runtime::Handle::current();
+        let shutdown_listener = ShutdownHandle::new().new_listener();
+        Arc::new(
+            ReportConfig::new("".to_string(), "".to_string())
+                .enable_in_memory()
+                .init_reporter(&runtime, shutdown_listener)
+                .unwrap(),
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn say_something_to_other_chatter() {
+        env_logger::init();
+        let bootstrap_server =
+            tokio::task::spawn_blocking(|| BootstrapSrv::new(Config::testing()).unwrap())
+                .await
+                .unwrap();
+        let bootstrap_server_url = format!("http://{}", bootstrap_server.listen_addrs()[0]);
+        let signal_server_url = format!("ws://{}", bootstrap_server.listen_addrs()[0]);
+
+        let reporter = test_reporter();
+        let space_id = Timestamp::now().as_micros().to_string();
+        let chatter_1 = WtChatter::create(
+            &bootstrap_server_url,
+            &signal_server_url,
+            &space_id,
+            reporter.clone(),
+        )
+        .await
+        .unwrap();
+        let chatter_2 = WtChatter::create(
+            &bootstrap_server_url,
+            &signal_server_url,
+            &space_id,
+            reporter,
+        )
+        .await
+        .unwrap();
+        let agent_1 = chatter_1.state.lock().await.agent.agent().clone();
+        let agent_2 = chatter_2.state.lock().await.agent.agent().clone();
+        chatter_1.join_space().await.unwrap();
+        chatter_2.join_space().await.unwrap();
+
+        // Bootstrapping takes about 10 seconds.
+        let now = Instant::now();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                if chatter_1
+                    .state
+                    .lock()
+                    .await
+                    .space
+                    .peer_store()
+                    .get_all()
+                    .await
+                    .unwrap()
+                    .len()
+                    == 2
+                    && chatter_2
+                        .state
+                        .lock()
+                        .await
+                        .space
+                        .peer_store()
+                        .get_all()
+                        .await
+                        .unwrap()
+                        .len()
+                        == 2
+                {
+                    break;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        log::info!("Bootstrapping took {:?}", now.elapsed());
+
+        // Each chatter says 3 messages.
+        let mut all_message_ids_1 = vec![];
+        let mut all_message_ids_2 = vec![];
+        for i in 0..3 {
+            let message_1 = format!("hello there {} {}", agent_1, i);
+            let message_2 = format!("hello there {} {}", agent_2, i);
+            let mut message_ids_1 = chatter_1.say(&message_1).await.unwrap();
+            let mut message_ids_2 = chatter_2.say(&message_2).await.unwrap();
+            all_message_ids_1.append(&mut message_ids_1);
+            all_message_ids_2.append(&mut message_ids_2);
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+
+        // Wait for both chatters to have received all messages.
+        let now = Instant::now();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                let ops_1 = chatter_2
+                    .state
+                    .lock()
+                    .await
+                    .space
+                    .op_store()
+                    .retrieve_ops(all_message_ids_1.clone())
+                    .await
+                    .unwrap();
+                let ops_2 = chatter_1
+                    .state
+                    .lock()
+                    .await
+                    .space
+                    .op_store()
+                    .retrieve_ops(all_message_ids_2.clone())
+                    .await
+                    .unwrap();
+                if ops_1.len() == all_message_ids_1.len() && ops_2.len() == all_message_ids_2.len()
+                {
+                    break;
+                } else {
+                    println!("ops 1 len {}/{}", ops_1.len(), all_message_ids_1.len());
+                    println!("ops 2 len {}/{}", ops_2.len(), all_message_ids_2.len());
+                }
+            }
+        })
+        .await
+        .unwrap();
+        log::info!(
+            "All messages received by all peers after {:?}",
+            now.elapsed()
+        );
+    }
+}

--- a/bindings/kitsune_client/src/op_store.rs
+++ b/bindings/kitsune_client/src/op_store.rs
@@ -1,0 +1,407 @@
+//! The mem op store implementation for WindTunnel.
+
+use bytes::Bytes;
+use kitsune2_api::{
+    AgentId, BoxFut, Builder, Config, DhtArc, DynOpStore, K2Error, K2Result, MetaOp, Op, OpId,
+    OpStore, OpStoreFactory, SpaceId, StoredOp, Timestamp,
+};
+use serde::{Deserialize, Serialize};
+use sha3::Digest;
+use std::collections::HashMap;
+use std::sync::Arc;
+use time_slice_hash_store::TimeSliceHashStore;
+use tokio::sync::RwLock;
+use wind_tunnel_instruments::prelude::{ReportMetric, Reporter};
+
+mod time_slice_hash_store;
+
+#[cfg(test)]
+mod test;
+
+#[derive(Debug)]
+pub(super) struct WtOpStoreFactory {
+    op_store: DynWtOpStore,
+}
+
+impl OpStoreFactory for WtOpStoreFactory {
+    fn create(
+        &self,
+        _builder: Arc<Builder>,
+        _space: SpaceId,
+    ) -> BoxFut<'static, K2Result<DynOpStore>> {
+        // A handle to the op store is required for direct manipulation with custom methods
+        // beyond the trait ones. Hence the factory is created with an op store and this `create`
+        // method, which is called when the space is created, will simply return it.
+        let op_store: DynOpStore = self.op_store.clone();
+        Box::pin(async move { Ok(op_store) })
+    }
+
+    fn default_config(&self, _config: &mut Config) -> K2Result<()> {
+        Ok(())
+    }
+
+    fn validate_config(&self, _config: &Config) -> K2Result<()> {
+        Ok(())
+    }
+}
+
+impl WtOpStoreFactory {
+    pub fn new(op_store: DynWtOpStore) -> Self {
+        Self { op_store }
+    }
+}
+
+/// A WindTunnel op which holds a string message as data.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WtOp {
+    /// The creation timestamp of this op.
+    pub created_at: Timestamp,
+    /// The data of the op.
+    pub op_data: Vec<u8>,
+}
+
+impl WtOp {
+    /// Create a new [MemoryOp].
+    pub fn new(timestamp: Timestamp, payload: Vec<u8>) -> Self {
+        Self {
+            created_at: timestamp,
+            op_data: payload,
+        }
+    }
+
+    /// Compute the op id for this op.
+    pub fn compute_op_id(&self) -> OpId {
+        if cfg!(test) {
+            // Note that this produces predictable op ids for testing purposes.
+            // It is simply the first 32 bytes of the op data.
+            let mut value = self.op_data.as_slice()[..32.min(self.op_data.len())].to_vec();
+            value.resize(32, 0);
+            OpId::from(bytes::Bytes::from(value))
+        } else {
+            // For WindTunnel scenarios a common hashing algorithm computes the op id.
+            let mut hasher = sha3::Sha3_256::new();
+            hasher.update(self.op_data.clone());
+            OpId::from(Bytes::copy_from_slice(&hasher.finalize()))
+        }
+    }
+}
+
+impl From<Bytes> for WtOp {
+    fn from(value: Bytes) -> Self {
+        serde_json::from_slice(&value).expect("failed to deserialize MemoryOp from bytes")
+    }
+}
+
+impl From<WtOp> for Bytes {
+    fn from(value: WtOp) -> Self {
+        serde_json::to_vec(&value)
+            .expect("failed to serialize MemoryOp to bytes")
+            .into()
+    }
+}
+
+/// This is the storage record for an op with computed fields.
+///
+/// Test data should create [MemoryOp]s and not be aware of this type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WtOpRecord {
+    /// The id (hash) of the op
+    pub op_id: OpId,
+    /// The creation timestamp of this op
+    pub created_at: Timestamp,
+    /// The timestamp at which this op was stored by us
+    pub stored_at: Timestamp,
+    /// The data for the op
+    pub op_data: Vec<u8>,
+}
+
+impl From<Bytes> for WtOpRecord {
+    fn from(value: Bytes) -> Self {
+        let inner: WtOp = value.into();
+        Self {
+            op_id: inner.compute_op_id(),
+            created_at: inner.created_at,
+            stored_at: Timestamp::now(),
+            op_data: inner.op_data,
+        }
+    }
+}
+
+impl From<WtOp> for StoredOp {
+    fn from(value: WtOp) -> Self {
+        StoredOp {
+            op_id: value.compute_op_id(),
+            created_at: value.created_at,
+        }
+    }
+}
+
+impl From<Op> for WtOp {
+    fn from(value: Op) -> Self {
+        value.data.into()
+    }
+}
+
+/// An in-memory op store for WindTunnel.
+#[derive(Debug)]
+pub(crate) struct WtOpStore {
+    agent_id: AgentId,
+    inner: RwLock<WtOpStoreInner>,
+    reporter: Arc<Reporter>,
+}
+
+/// WtOpStore trait object.
+pub(crate) type DynWtOpStore = Arc<WtOpStore>;
+
+impl WtOpStore {
+    pub fn new(agent_id: AgentId, reporter: Arc<Reporter>) -> Self {
+        Self {
+            agent_id,
+            inner: Default::default(),
+            reporter,
+        }
+    }
+
+    pub async fn store_op(&self, op: WtOp) -> anyhow::Result<Vec<OpId>> {
+        let op_record = WtOpRecord::from(Bytes::from(op));
+        let inserted_op_ids = match self
+            .inner
+            .write()
+            .await
+            .op_list
+            .insert(op_record.op_id.clone(), op_record)
+        {
+            None => vec![],
+            Some(op) => vec![op.op_id],
+        };
+        Ok(inserted_op_ids)
+    }
+}
+
+impl std::ops::Deref for WtOpStore {
+    type Target = RwLock<WtOpStoreInner>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// WindTunnel op store inner state.
+#[derive(Debug, Default)]
+pub(crate) struct WtOpStoreInner {
+    op_list: HashMap<OpId, WtOpRecord>,
+    time_slice_hashes: TimeSliceHashStore,
+}
+
+impl OpStore for WtOpStore {
+    fn process_incoming_ops(&self, op_list: Vec<Bytes>) -> BoxFut<'_, K2Result<Vec<OpId>>> {
+        Box::pin(async move {
+            let ops_to_add = op_list
+                .iter()
+                .map(|op| -> serde_json::Result<(OpId, WtOpRecord)> {
+                    let op = WtOpRecord::from(op.clone());
+                    Ok((op.op_id.clone(), op))
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| {
+                    K2Error::other_src("Failed to deserialize op data, are you using `WtOp`s?", e)
+                })?;
+
+            let mut op_ids = Vec::with_capacity(ops_to_add.len());
+            let mut lock = self.write().await;
+            for (op_id, record) in ops_to_add {
+                if let std::collections::hash_map::Entry::Vacant(entry) =
+                    lock.op_list.entry(op_id.clone())
+                {
+                    entry.insert(record);
+                    op_ids.push(op_id);
+                }
+            }
+
+            // After inserting incoming ops into the store, the number of inserted ops is reported.
+            let amount = op_ids.len();
+            log::info!("{} ops have come in to {}", amount, self.agent_id);
+            if amount > 0 {
+                // Kitsune is calling this method with empty vectors. Work around it by not reporting
+                // such events.
+                self.reporter.add_custom(
+                    ReportMetric::new("number_of_incoming_ops")
+                        .with_tag("agent_id", self.agent_id.to_string())
+                        .with_field("number_of_incoming_ops", amount as u32),
+                );
+            }
+
+            Ok(op_ids)
+        })
+    }
+
+    fn retrieve_op_hashes_in_time_slice(
+        &self,
+        arc: DhtArc,
+        start: Timestamp,
+        end: Timestamp,
+    ) -> BoxFut<'_, K2Result<(Vec<OpId>, u32)>> {
+        Box::pin(async move {
+            let self_lock = self.read().await;
+
+            let mut used_bytes = 0;
+            let mut candidate_ops = self_lock
+                .op_list
+                .iter()
+                .filter(|(_, op)| {
+                    let loc = op.op_id.loc();
+                    op.created_at >= start && op.created_at < end && arc.contains(loc)
+                })
+                .collect::<Vec<_>>();
+            candidate_ops.sort_by_key(|a| a.1.created_at);
+
+            Ok((
+                candidate_ops
+                    .iter()
+                    .map(|(op_id, record)| {
+                        used_bytes += record.op_data.len() as u32;
+                        (*op_id).clone()
+                    })
+                    .collect(),
+                used_bytes,
+            ))
+        })
+    }
+
+    fn retrieve_ops(&self, op_ids: Vec<OpId>) -> BoxFut<'_, K2Result<Vec<MetaOp>>> {
+        Box::pin(async move {
+            let self_lock = self.read().await;
+            Ok(op_ids
+                .iter()
+                .filter_map(|op_id| {
+                    self_lock.op_list.get(op_id).map(|op| MetaOp {
+                        op_id: op.op_id.clone(),
+                        op_data: WtOp {
+                            created_at: op.created_at,
+                            op_data: op.op_data.clone(),
+                        }
+                        .into(),
+                    })
+                })
+                .collect())
+        })
+    }
+
+    fn retrieve_op_ids_bounded(
+        &self,
+        arc: DhtArc,
+        start: Timestamp,
+        limit_bytes: u32,
+    ) -> BoxFut<'_, K2Result<(Vec<OpId>, u32, Timestamp)>> {
+        Box::pin(async move {
+            let new_start = Timestamp::now();
+
+            let self_lock = self.read().await;
+
+            // Capture all ops that are within the arc and after the start time
+            let mut candidate_ops = self_lock
+                .op_list
+                .values()
+                .filter(|op| arc.contains(op.op_id.loc()) && op.stored_at >= start)
+                .collect::<Vec<_>>();
+
+            // Sort the ops by the time they were stored
+            candidate_ops.sort_by(|a, b| a.stored_at.cmp(&b.stored_at));
+
+            // Now take as many ops as we can up to the limit
+            let mut total_bytes = 0;
+            let mut last_op_timestamp = None;
+            let op_ids = candidate_ops
+                .into_iter()
+                .take_while(|op| {
+                    let data_len = op.op_data.len() as u32;
+                    if total_bytes + data_len <= limit_bytes {
+                        total_bytes += data_len;
+                        true
+                    } else {
+                        last_op_timestamp = Some(op.stored_at);
+                        false
+                    }
+                })
+                .map(|op| op.op_id.clone())
+                .collect();
+
+            Ok((
+                op_ids,
+                total_bytes,
+                if let Some(ts) = last_op_timestamp {
+                    ts
+                } else {
+                    new_start
+                },
+            ))
+        })
+    }
+
+    /// Store the combined hash of a time slice.
+    ///
+    /// The `slice_id` is the index of the time slice. This is a 0-based index. So for a given
+    /// time period being used to slice time, the first `slice_hash` at `slice_id` 0 would
+    /// represent the combined hash of all known ops in the time slice `[0, period)`. Then `slice_id`
+    /// 1 would represent the combined hash of all known ops in the time slice `[period, 2*period)`.
+    fn store_slice_hash(
+        &self,
+        arc: DhtArc,
+        slice_index: u64,
+        slice_hash: bytes::Bytes,
+    ) -> BoxFut<'_, K2Result<()>> {
+        Box::pin(async move {
+            self.write()
+                .await
+                .time_slice_hashes
+                .insert(arc, slice_index, slice_hash)
+        })
+    }
+
+    /// Retrieve the count of time slice hashes stored.
+    ///
+    /// Note that this is not the total number of hashes of a time slice at a unique `slice_id`.
+    /// This value is the count, based on the highest stored id, starting from time slice id 0 and counting up to the highest stored id. In other words it is the id of the most recent time slice plus 1.
+    ///
+    /// This value is easier to compare between peers because it ignores sync progress. A simple
+    /// count cannot tell the difference between a peer that has synced the first 4 time slices,
+    /// and a peer who has synced the first 3 time slices and created one recent one. However,
+    /// using the highest stored id shows the difference to be 4 and say 300 respectively.
+    /// Equally, the literal count is more useful if the DHT contains a large amount of data and
+    /// a peer might allocate a recent full slice before completing its initial sync. That situation
+    /// could be created by a configuration that chooses small time-slices. However, in the general
+    /// case, the highest stored id is more useful.
+    fn slice_hash_count(&self, arc: DhtArc) -> BoxFut<'_, K2Result<u64>> {
+        // +1 to convert from a 0-based index to a count
+        Box::pin(async move {
+            Ok(self
+                .read()
+                .await
+                .time_slice_hashes
+                .highest_stored_id(&arc)
+                .map(|id| id + 1)
+                .unwrap_or_default())
+        })
+    }
+
+    /// Retrieve the hash of a time slice.
+    ///
+    /// This must be the same value provided by the caller to `store_slice_hash` for the same `slice_id`.
+    /// If `store_slice_hash` has been called multiple times for the same `slice_id`, the most recent value is returned.
+    /// If the caller has never provided a value for this `slice_id`, return `None`.
+    fn retrieve_slice_hash(
+        &self,
+        arc: DhtArc,
+        slice_index: u64,
+    ) -> BoxFut<'_, K2Result<Option<bytes::Bytes>>> {
+        Box::pin(async move { Ok(self.read().await.time_slice_hashes.get(&arc, slice_index)) })
+    }
+
+    /// Retrieve the hashes of all time slices.
+    fn retrieve_slice_hashes(&self, arc: DhtArc) -> BoxFut<'_, K2Result<Vec<(u64, bytes::Bytes)>>> {
+        Box::pin(async move {
+            let self_lock = self.read().await;
+            Ok(self_lock.time_slice_hashes.get_all(&arc))
+        })
+    }
+}

--- a/bindings/kitsune_client/src/op_store/test.rs
+++ b/bindings/kitsune_client/src/op_store/test.rs
@@ -1,0 +1,204 @@
+use super::WtOpStore;
+use crate::tests::test_reporter;
+use bytes::Bytes;
+use kitsune2_api::{AgentId, DhtArc, Id, OpStore, Timestamp};
+use kitsune2_core::factories::MemoryOp;
+use std::time::Duration;
+
+async fn test_op_store() -> WtOpStore {
+    let timestamp = Timestamp::now();
+    let agent_id = AgentId(Id(Bytes::copy_from_slice(
+        timestamp.as_micros().to_string().as_bytes(),
+    )));
+    let reporter = test_reporter();
+    WtOpStore::new(agent_id, reporter)
+}
+
+#[test]
+fn happy_op_to_bytes() {
+    let op = MemoryOp {
+        created_at: Timestamp::now(),
+        op_data: vec![0],
+    };
+    let bytes = Bytes::from(op.clone());
+    let decoded_op = MemoryOp::from(bytes);
+    assert_eq!(op, decoded_op);
+}
+
+#[tokio::test]
+async fn process_incoming_ops_and_retrieve() {
+    let op_store = test_op_store().await;
+    let op_1 = MemoryOp {
+        created_at: Timestamp::from_micros(0),
+        op_data: vec![1],
+    };
+    let op_2 = MemoryOp {
+        created_at: Timestamp::from_micros(0),
+        op_data: vec![2],
+    };
+    let op_list = vec![Bytes::from(op_1.clone()), Bytes::from(op_2.clone())];
+
+    op_store
+        .process_incoming_ops(op_list.clone())
+        .await
+        .unwrap();
+
+    let op_ids = vec![op_1.compute_op_id(), op_2.compute_op_id()];
+    let ops = op_store.retrieve_ops(op_ids).await.unwrap();
+    assert_eq!(
+        ops.into_iter().map(|op| op.op_data).collect::<Vec<_>>(),
+        op_list
+    );
+}
+
+#[tokio::test]
+async fn op_hashes_in_time_slice() {
+    let op_store = test_op_store().await;
+    let included_op_1 = MemoryOp {
+        created_at: Timestamp::from_micros(10),
+        op_data: vec![1],
+    };
+    let included_op_id_1 = included_op_1.compute_op_id();
+    let included_op_2 = MemoryOp {
+        created_at: Timestamp::from_micros(0),
+        op_data: vec![2],
+    };
+    let included_op_id_2 = included_op_2.compute_op_id();
+    let excluded_op_1 = MemoryOp {
+        created_at: Timestamp::from_micros(100),
+        op_data: vec![3],
+    };
+    let excluded_op_2 = MemoryOp {
+        created_at: Timestamp::from_micros(0),
+        op_data: vec![101],
+    };
+
+    let _ = op_store
+        .process_incoming_ops(vec![
+            included_op_1.clone().into(),
+            included_op_2.clone().into(),
+            excluded_op_1.into(),
+            excluded_op_2.into(),
+        ])
+        .await
+        .unwrap();
+
+    let arc = DhtArc::Arc(0, 100);
+    let start = Timestamp::from_micros(0);
+    let end = Timestamp::from_micros(100);
+    let (op_hashes, bytes) = op_store
+        .retrieve_op_hashes_in_time_slice(arc, start, end)
+        .await
+        .unwrap();
+
+    let expected_op_hashes = vec![included_op_id_2, included_op_id_1];
+    let expected_bytes = (included_op_1.op_data.len() + included_op_2.op_data.len()) as u32;
+    assert_eq!((op_hashes, bytes), (expected_op_hashes, expected_bytes));
+}
+
+#[tokio::test]
+async fn bounded_op_ids() {
+    let op_store = test_op_store().await;
+    let included_op_1 = MemoryOp {
+        created_at: Timestamp::from_micros(0),
+        op_data: vec![1; 9],
+    };
+    let included_op_id_1 = included_op_1.compute_op_id();
+    let excess_op_1 = MemoryOp {
+        created_at: Timestamp::from_micros(0),
+        op_data: vec![1; 3],
+    };
+    let excluded_op_1 = MemoryOp {
+        created_at: Timestamp::from_micros(0),
+        op_data: vec![1],
+    };
+    let excluded_op_2 = MemoryOp {
+        created_at: Timestamp::from_micros(0),
+        op_data: vec![255],
+    };
+
+    // Store op to be excluded first.
+    let _ = op_store
+        .process_incoming_ops(vec![excluded_op_1.into()])
+        .await
+        .unwrap();
+    // Then wait some to produce a different `stored_at` timestamp and store the rest.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    let timestamp = Timestamp::now();
+    let _ = op_store
+        .process_incoming_ops(vec![
+            included_op_1.clone().into(),
+            excess_op_1.clone().into(),
+            excluded_op_2.into(),
+        ])
+        .await
+        .unwrap();
+
+    let (op_ids, bytes, next_timestamp) = op_store
+        .retrieve_op_ids_bounded(DhtArc::Arc(0, 100), timestamp, 10)
+        .await
+        .unwrap();
+    assert_eq!(op_ids, vec![included_op_id_1]);
+    assert_eq!(bytes, included_op_1.op_data.len() as u32);
+    assert!(next_timestamp > timestamp);
+}
+
+#[tokio::test]
+async fn insert_empty_hash() {
+    let op_store = test_op_store().await;
+    let arc = DhtArc::Arc(10, 100);
+
+    let insert_empty_hash_result = op_store.store_slice_hash(arc, 0, Bytes::new()).await;
+    assert!(insert_empty_hash_result.is_err());
+}
+
+#[tokio::test]
+async fn insert_and_retrieve_time_slice_hash() {
+    let op_store = test_op_store().await;
+    let arc = DhtArc::Arc(10, 100);
+
+    let slice_hash_0 = Bytes::from_static(b"slice_hash_0");
+    op_store
+        .store_slice_hash(arc, 0, slice_hash_0.clone())
+        .await
+        .unwrap();
+
+    let slice_hash_count = op_store.slice_hash_count(arc).await.unwrap();
+    assert_eq!(slice_hash_count, 1);
+    let slice_hashes = op_store.retrieve_slice_hashes(arc).await.unwrap();
+    assert_eq!(slice_hashes, vec![(0, slice_hash_0.clone())]);
+
+    let actual_slice_hash_0 = op_store.retrieve_slice_hash(arc, 0).await.unwrap();
+    assert_eq!(actual_slice_hash_0, Some(slice_hash_0));
+
+    let retrieve_non_existing_arc_hash = op_store
+        .retrieve_slice_hash(DhtArc::Arc(1, 10), 0)
+        .await
+        .unwrap();
+    assert!(retrieve_non_existing_arc_hash.is_none());
+}
+
+#[tokio::test]
+async fn highest_stored_slice_hash() {
+    let op_store = test_op_store().await;
+    let arc = DhtArc::Arc(10, 100);
+    let slice_hash_count = op_store.slice_hash_count(arc).await.unwrap();
+    assert_eq!(slice_hash_count, 0);
+
+    let highest_slice_hash = Bytes::from_static(b"highest_slice_hash");
+    op_store
+        .store_slice_hash(arc, 20, highest_slice_hash.clone())
+        .await
+        .unwrap();
+
+    let slice_hash_count = op_store.slice_hash_count(arc).await.unwrap();
+    assert_eq!(slice_hash_count, 21);
+
+    op_store
+        .store_slice_hash(arc, 2, Bytes::from_static(b"lower_slice_hash"))
+        .await
+        .unwrap();
+
+    let slice_hash_count = op_store.slice_hash_count(arc).await.unwrap();
+    assert_eq!(slice_hash_count, 21);
+}

--- a/bindings/kitsune_client/src/op_store/time_slice_hash_store.rs
+++ b/bindings/kitsune_client/src/op_store/time_slice_hash_store.rs
@@ -1,0 +1,248 @@
+use kitsune2_api::{DhtArc, K2Error, K2Result};
+use std::collections::{BTreeMap, HashMap};
+
+/// In-memory store for time slice hashes.
+///
+/// Empty hashes do not need to be stored, and will be rejected with an error if you try to insert
+/// one. Hashes that are stored, are stored sparsely, and are indexed by the slice id.
+///
+/// It is valid to look up a time slice which has not had a hash stored, and you will get a `None`
+/// response. Otherwise, you will get exactly what was most recently stored for that slice id.
+#[derive(Debug, Default)]
+#[cfg_attr(test, derive(Clone))]
+pub struct TimeSliceHashStore {
+    inner: HashMap<DhtArc, BTreeMap<u64, bytes::Bytes>>,
+}
+
+impl TimeSliceHashStore {
+    /// Insert a hash at the given slice id.
+    pub fn insert(&mut self, arc: DhtArc, slice_id: u64, hash: bytes::Bytes) -> K2Result<()> {
+        // This doesn't need to be supported. If we receive an empty hash
+        // for a slice id after we've already stored a non-empty hash for
+        // that slice id, then the caller has done something wrong.
+        // Alternatively, if we've computed an empty hash for a time slice, then we don't
+        // need to store that.
+        if hash.is_empty() {
+            return Err(K2Error::other("Cannot insert empty combined hash"));
+        }
+
+        self.inner.entry(arc).or_default().insert(slice_id, hash);
+
+        Ok(())
+    }
+
+    pub fn get(&self, arc: &DhtArc, slice_id: u64) -> Option<bytes::Bytes> {
+        self.inner
+            .get(arc)
+            .and_then(|by_arc| by_arc.get(&slice_id))
+            .cloned()
+    }
+
+    pub fn get_all(&self, arc: &DhtArc) -> Vec<(u64, bytes::Bytes)> {
+        self.inner
+            .get(arc)
+            .map(|by_arc| {
+                by_arc
+                    .iter()
+                    .map(|(id, hash)| (*id, hash.clone()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn highest_stored_id(&self, arc: &DhtArc) -> Option<u64> {
+        self.inner
+            .get(arc)
+            .and_then(|by_arc| by_arc.iter().last().map(|(id, _)| *id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_empty() {
+        let store = TimeSliceHashStore::default();
+
+        assert_eq!(None, store.highest_stored_id(&DhtArc::Arc(0, 0)));
+        assert!(store.inner.is_empty());
+    }
+
+    #[test]
+    fn insert_empty_hash_into_empty() {
+        let mut store = TimeSliceHashStore::default();
+
+        let e = store
+            .insert(DhtArc::Arc(0, 2), 100, bytes::Bytes::new())
+            .unwrap_err();
+        assert_eq!(
+            "Cannot insert empty combined hash (src: None)",
+            e.to_string()
+        );
+    }
+
+    #[test]
+    fn insert_single_hash_into_empty() {
+        let mut store = TimeSliceHashStore::default();
+
+        let arc_constraint = DhtArc::Arc(0, 2);
+        store
+            .insert(arc_constraint, 100, vec![1, 2, 3].into())
+            .unwrap();
+
+        assert_eq!(1, store.inner.len());
+        assert_eq!(
+            bytes::Bytes::from_static(&[1, 2, 3]),
+            store.get(&arc_constraint, 100).unwrap()
+        );
+        assert_eq!(Some(100), store.highest_stored_id(&arc_constraint));
+    }
+
+    #[test]
+    fn insert_many_sparse() {
+        let mut store = TimeSliceHashStore::default();
+
+        let arc_constraint = DhtArc::Arc(0, 2);
+        store
+            .insert(arc_constraint, 100, vec![1, 2, 3].into())
+            .unwrap();
+        store
+            .insert(arc_constraint, 105, vec![2, 3, 4].into())
+            .unwrap();
+        store
+            .insert(arc_constraint, 115, vec![3, 4, 5].into())
+            .unwrap();
+
+        assert_eq!(1, store.inner.len());
+        assert_eq!(3, store.inner[&arc_constraint].len());
+        assert_eq!(
+            bytes::Bytes::from_static(&[1, 2, 3]),
+            store.get(&arc_constraint, 100).unwrap()
+        );
+        assert_eq!(
+            bytes::Bytes::from_static(&[2, 3, 4]),
+            store.get(&arc_constraint, 105).unwrap()
+        );
+        assert_eq!(
+            bytes::Bytes::from_static(&[3, 4, 5]),
+            store.get(&arc_constraint, 115).unwrap()
+        );
+        assert_eq!(Some(115), store.highest_stored_id(&arc_constraint));
+    }
+
+    #[test]
+    fn insert_many_in_sequence() {
+        let mut store = TimeSliceHashStore::default();
+
+        let arc_constraint = DhtArc::Arc(0, 2);
+        store
+            .insert(arc_constraint, 100, vec![1, 2, 3].into())
+            .unwrap();
+        store
+            .insert(arc_constraint, 101, vec![2, 3, 4].into())
+            .unwrap();
+        store
+            .insert(arc_constraint, 102, vec![3, 4, 5].into())
+            .unwrap();
+
+        assert_eq!(1, store.inner.len());
+        assert_eq!(3, store.inner[&arc_constraint].len());
+
+        assert_eq!(
+            bytes::Bytes::from_static(&[1, 2, 3]),
+            store.get(&arc_constraint, 100).unwrap()
+        );
+        assert_eq!(
+            bytes::Bytes::from_static(&[2, 3, 4]),
+            store.get(&arc_constraint, 101).unwrap()
+        );
+        assert_eq!(
+            bytes::Bytes::from_static(&[3, 4, 5]),
+            store.get(&arc_constraint, 102).unwrap()
+        );
+        assert_eq!(Some(102), store.highest_stored_id(&arc_constraint));
+    }
+
+    #[test]
+    fn overwrite_existing_hash() {
+        let mut store = TimeSliceHashStore::default();
+
+        let arc_constraint = DhtArc::Arc(0, 2);
+        store
+            .insert(arc_constraint, 100, vec![1, 2, 3].into())
+            .unwrap();
+        assert_eq!(1, store.inner.len());
+
+        store
+            .insert(arc_constraint, 100, vec![2, 3, 4].into())
+            .unwrap();
+        assert_eq!(1, store.inner.len());
+    }
+
+    #[test]
+    fn overlapping_arcs_are_kept_separate() {
+        let mut store = TimeSliceHashStore::default();
+
+        let arc_constraint_1 = DhtArc::Arc(0, 2);
+
+        // Twice the size of arc_constraint_1, starting at the same point
+        let arc_constraint_2 = DhtArc::Arc(0, 4);
+
+        store
+            .insert(arc_constraint_1, 100, vec![1, 2, 3].into())
+            .unwrap();
+
+        store
+            .insert(arc_constraint_2, 100, vec![2, 3, 4].into())
+            .unwrap();
+
+        assert_eq!(2, store.inner.len());
+        assert_eq!(Some(100), store.highest_stored_id(&arc_constraint_1));
+        assert_eq!(vec![1, 2, 3], store.get(&arc_constraint_1, 100).unwrap());
+
+        assert_eq!(Some(100), store.highest_stored_id(&arc_constraint_2));
+        assert_eq!(vec![2, 3, 4], store.get(&arc_constraint_2, 100).unwrap());
+    }
+
+    #[test]
+    fn update_with_multiple_arcs() {
+        let mut store = TimeSliceHashStore::default();
+
+        let arc_constraint_1 = DhtArc::Arc(0, 2);
+        let arc_constraint_2 = DhtArc::Arc(2, 4);
+
+        store
+            .insert(arc_constraint_1, 0, vec![1, 2, 3].into())
+            .unwrap();
+        store
+            .insert(arc_constraint_1, 1, vec![2, 3, 4].into())
+            .unwrap();
+        store
+            .insert(arc_constraint_2, 0, vec![3, 2, 1].into())
+            .unwrap();
+        store
+            .insert(arc_constraint_2, 1, vec![4, 3, 2].into())
+            .unwrap();
+
+        assert_eq!(2, store.inner.len());
+        assert_eq!(Some(1), store.highest_stored_id(&arc_constraint_1));
+        assert_eq!(Some(1), store.highest_stored_id(&arc_constraint_2));
+
+        store
+            .insert(arc_constraint_1, 0, vec![1, 2, 5].into())
+            .unwrap();
+        store
+            .insert(arc_constraint_2, 1, vec![5, 3, 2].into())
+            .unwrap();
+
+        assert_eq!(2, store.inner.len());
+        assert_eq!(Some(1), store.highest_stored_id(&arc_constraint_1));
+        assert_eq!(vec![1, 2, 5], store.get(&arc_constraint_1, 0).unwrap());
+        assert_eq!(vec![2, 3, 4], store.get(&arc_constraint_1, 1).unwrap());
+
+        assert_eq!(Some(1), store.highest_stored_id(&arc_constraint_2));
+        assert_eq!(vec![3, 2, 1], store.get(&arc_constraint_2, 0).unwrap());
+        assert_eq!(vec![5, 3, 2], store.get(&arc_constraint_2, 1).unwrap());
+    }
+}

--- a/bindings/kitsune_runner/Cargo.toml
+++ b/bindings/kitsune_runner/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "kitsune_wind_tunnel_runner"
+version = "0.4.0-alpha.1"
+description = "Customizes the wind_tunnel_runner for kitsune testing"
+license = "MIT"
+authors = ["Holochain Dev Team <devcore@holochain.org>"]
+edition = "2021"
+categories = ["development-tools::testing", "development-tools::profiling"]
+homepage = "https://github.com/holochain/wind-tunnel"
+repository = "https://github.com/holochain/wind-tunnel"
+
+[dependencies]
+anyhow = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha3 = { workspace = true }
+tokio = { workspace = true }
+
+kitsune_client_instrumented = { workspace = true }
+wind_tunnel_runner = { workspace = true }
+
+[lints]
+workspace = true

--- a/bindings/kitsune_runner/src/cli.rs
+++ b/bindings/kitsune_runner/src/cli.rs
@@ -1,0 +1,76 @@
+use crate::common::to_connection_string;
+use clap::Parser;
+use wind_tunnel_runner::parse_agent_behaviour;
+use wind_tunnel_runner::prelude::{ReporterOpt, WindTunnelScenarioCli};
+
+#[derive(Parser)]
+#[command(about, long_about = None)]
+pub struct WindTunnelKitsuneScenarioCli {
+    /// The bootstrap server URL.
+    #[clap(long)]
+    pub bootstrap_server_url: String,
+
+    /// The signal server URL.
+    #[clap(long)]
+    pub signal_server_url: String,
+
+    /// The number of agents to run. All agents will run on the local machine.
+    /// Each agent creates an instance of "Chatter", the WindTunnel kitsune2 app.
+    /// Once an agent has joined the chatter space, it will be communicating with
+    /// the other agents.
+    #[clap(long)]
+    pub agents: Option<usize>,
+
+    /// The number of seconds to run the scenario for.
+    #[clap(long)]
+    pub duration: Option<u64>,
+
+    /// Assign a behaviour to a number of agents. Specify the behaviour and number of agents to assign
+    /// it to in the format `behaviour:count`. For example `--behaviour=login:5`.
+    ///
+    /// Specifying the count is optional and will default to 1. This is a useful default if you want to
+    /// run distributed tests and want a single agent to use a single behaviour on that node.
+    ///
+    /// You can specify multiple behaviours by using the flag multiple times. For example `--behaviour=add_to_list:5 --behaviour=favourite_items:5`.
+    ///
+    /// For however many agents you assign to behaviours in total, it must be less than or equal to the total number of agents for this scenario.
+    /// If it is less than the total number of agents then the remaining agents will be assigned the default behaviour.
+    ///
+    /// If the configuration is invalid then the scenario will fail to start.
+    #[clap(long, short, value_parser = parse_agent_behaviour)]
+    pub behaviour: Vec<(String, usize)>,
+
+    /// Run this test as a soak test, ignoring any configured duration and continuing to run until stopped.
+    #[clap(long, default_value = "false")]
+    pub soak: bool,
+
+    /// Do not show a progress bar on the CLI.
+    ///
+    /// This is recommended for CI/CD environments where the progress bar isn't being looked at by anyone and is just adding noise to the logs.
+    #[clap(long, default_value = "false")]
+    pub no_progress: bool,
+
+    /// The reporter to use.
+    #[arg(long, value_enum, default_value_t = ReporterOpt::InMemory)]
+    pub reporter: ReporterOpt,
+}
+
+impl TryInto<WindTunnelScenarioCli> for WindTunnelKitsuneScenarioCli {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<WindTunnelScenarioCli, Self::Error> {
+        // Build connection string from bootstrap and signal server URLs.
+        let connection_string =
+            to_connection_string(self.bootstrap_server_url, self.signal_server_url);
+
+        Ok(WindTunnelScenarioCli {
+            connection_string,
+            agents: self.agents,
+            behaviour: self.behaviour,
+            duration: self.duration,
+            soak: self.soak,
+            no_progress: self.no_progress,
+            reporter: self.reporter,
+        })
+    }
+}

--- a/bindings/kitsune_runner/src/common.rs
+++ b/bindings/kitsune_runner/src/common.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use crate::{KitsuneAgentContext, KitsuneRunnerContext};
+use anyhow::Context;
+use kitsune_client_instrumented::WtChatter;
+use serde::{Deserialize, Serialize};
+use wind_tunnel_runner::prelude::{
+    AgentContext, HookResult, ScenarioDefinitionBuilder, WindTunnelResult,
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct KitsuneServerUrls {
+    bootstrap_server_url: String,
+    signal_server_url: String,
+}
+
+/// Parse cli argument "connection-string" for bootstrap and signal server URLs and return
+/// them separately.
+pub fn get_server_urls(
+    ctx: &AgentContext<KitsuneRunnerContext, KitsuneAgentContext>,
+) -> anyhow::Result<(String, String)> {
+    let connections =
+        serde_json::from_str::<KitsuneServerUrls>(ctx.runner_context().get_connection_string())
+            .context("failed to parse bootstrap and server URL from connection string")?;
+    Ok((
+        connections.bootstrap_server_url,
+        connections.signal_server_url,
+    ))
+}
+
+/// Convert bootstrap and signal server URL into single connection string.
+pub fn to_connection_string(bootstrap_server_url: String, signal_server_url: String) -> String {
+    let server_urls = KitsuneServerUrls {
+        bootstrap_server_url,
+        signal_server_url,
+    };
+    serde_json::to_string(&server_urls)
+        .expect("failed to convert bootstrap and signal server URLs to connection string")
+}
+
+/// Create a kitsune app instance.
+pub fn create_chatter(
+    ctx: &mut AgentContext<KitsuneRunnerContext, KitsuneAgentContext>,
+) -> HookResult {
+    let (bootstrap_server_url, signal_server_url) = get_server_urls(ctx)?;
+    let space_id = ctx.runner_context().get_run_id();
+    let reporter = ctx.runner_context().reporter();
+    let chatter = ctx
+        .runner_context()
+        .executor()
+        .execute_in_place(async move {
+            WtChatter::create(
+                &bootstrap_server_url,
+                &signal_server_url,
+                space_id,
+                reporter,
+            )
+            .await
+        })?;
+    ctx.get_mut().chatter = Some(Arc::new(chatter));
+    Ok(())
+}
+
+/// Join the chatter space.
+pub fn join_chatter_space(
+    ctx: &mut AgentContext<KitsuneRunnerContext, KitsuneAgentContext>,
+) -> HookResult {
+    let chatter = ctx.get().get_chatter();
+    ctx.runner_context()
+        .executor()
+        .execute_in_place(async move { chatter.join_space().await })?;
+    Ok(())
+}
+
+/// Send a message to peers.
+pub fn say(
+    ctx: &mut AgentContext<KitsuneRunnerContext, KitsuneAgentContext>,
+    message: &str,
+) -> anyhow::Result<()> {
+    let chatter = ctx.get().get_chatter();
+    ctx.runner_context()
+        .executor()
+        .execute_in_place(async move { chatter.say(message).await })?;
+    Ok(())
+}
+
+/// Run Kitsune scenario with WindTunnel runner.
+pub fn run(
+    definition: ScenarioDefinitionBuilder<KitsuneRunnerContext, KitsuneAgentContext>,
+) -> WindTunnelResult<usize> {
+    wind_tunnel_runner::prelude::run(definition)
+}

--- a/bindings/kitsune_runner/src/context.rs
+++ b/bindings/kitsune_runner/src/context.rs
@@ -1,0 +1,19 @@
+use kitsune_client_instrumented::WtChatter;
+use std::{fmt::Debug, sync::Arc};
+use wind_tunnel_runner::prelude::UserValuesConstraint;
+
+/// Kitsune specific agent context values.
+#[derive(Debug, Default)]
+pub struct KitsuneAgentContext {
+    pub(crate) chatter: Option<Arc<WtChatter>>,
+}
+
+impl UserValuesConstraint for KitsuneAgentContext {}
+
+impl KitsuneAgentContext {
+    pub fn get_chatter(&self) -> Arc<WtChatter> {
+        self.chatter.clone().expect(
+            "chatter is not set, did you forget to call `create_chatter` in your agent setup?",
+        )
+    }
+}

--- a/bindings/kitsune_runner/src/definition.rs
+++ b/bindings/kitsune_runner/src/definition.rs
@@ -1,0 +1,26 @@
+use crate::cli::WindTunnelKitsuneScenarioCli;
+use clap::Parser;
+use wind_tunnel_runner::prelude::{ScenarioDefinitionBuilder, UserValuesConstraint};
+
+pub struct KitsuneScenarioDefinitionBuilder<RV: UserValuesConstraint, AV: UserValuesConstraint> {
+    inner: ScenarioDefinitionBuilder<RV, AV>,
+}
+
+impl<RV: UserValuesConstraint, AV: UserValuesConstraint> KitsuneScenarioDefinitionBuilder<RV, AV> {
+    /// See [ScenarioDefinitionBuilder::new_with_init].
+    ///
+    /// This function uses [WindTunnelKitsuneScenarioCli] instead of [wind_tunnel_runner::prelude::WindTunnelScenarioCli].
+    pub fn new_with_init(name: &str) -> anyhow::Result<Self> {
+        env_logger::init();
+        let cli = WindTunnelKitsuneScenarioCli::parse();
+        Ok(Self {
+            inner: ScenarioDefinitionBuilder::new(name, cli.try_into()?),
+        })
+    }
+
+    /// Once the Kitsune customisations have been made, use this function to switch back to
+    /// configuring default properties for the scenario.
+    pub fn into_std(self) -> ScenarioDefinitionBuilder<RV, AV> {
+        self.inner
+    }
+}

--- a/bindings/kitsune_runner/src/lib.rs
+++ b/bindings/kitsune_runner/src/lib.rs
@@ -1,0 +1,18 @@
+use prelude::{KitsuneAgentContext, KitsuneRunnerContext};
+
+mod cli;
+mod common;
+mod context;
+mod definition;
+mod runner_context;
+
+pub mod prelude {
+    pub use super::{
+        common::{create_chatter, join_chatter_space, run, say},
+        context::KitsuneAgentContext,
+        definition::KitsuneScenarioDefinitionBuilder,
+        runner_context::KitsuneRunnerContext,
+    };
+
+    pub use wind_tunnel_runner::prelude::*;
+}

--- a/bindings/kitsune_runner/src/runner_context.rs
+++ b/bindings/kitsune_runner/src/runner_context.rs
@@ -1,0 +1,6 @@
+use wind_tunnel_runner::prelude::UserValuesConstraint;
+
+/// Kitsune specific runner context values.
+#[derive(Debug, Default)]
+pub struct KitsuneRunnerContext;
+impl UserValuesConstraint for KitsuneRunnerContext {}

--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1739936662,
-        "narHash": "sha256-x4syUjNUuRblR07nDPeLDP7DpphaBVbUaSoeZkFbGSk=",
+        "lastModified": 1739053031,
+        "narHash": "sha256-LrMDRuwAlRFD2T4MgBSRd1s2VtOE+Vl1oMCNu3RpPE0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "19de14aaeb869287647d9461cbd389187d8ecdb7",
+        "rev": "112e6591b2d6313b1bd05a80a754a8ee42432a7e",
         "type": "github"
       },
       "original": {
@@ -46,6 +46,24 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1740872218,
@@ -81,11 +99,11 @@
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1740552770,
-        "narHash": "sha256-jBO0KgYrYnk+X2XkdTKlSCwuzmY1hP8PjoErhTsIgQY=",
+        "lastModified": 1738575491,
+        "narHash": "sha256-jyXC95dVjy9LeQF/BnZyQ/zczpnfh/O0wWPA/11AOzE=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "2345fc1bead03d702116ac2ff7c6391bef6858ef",
+        "rev": "866ddd77fff967c25b08cd128b743cb05b8769bc",
         "type": "github"
       },
       "original": {
@@ -132,17 +150,43 @@
         ]
       },
       "locked": {
-        "lastModified": 1740557743,
-        "narHash": "sha256-7IIX1ZGNFRPjCeJy4VBd2HmfEKX6H3e+LM8a7glr++M=",
+        "lastModified": 1738586642,
+        "narHash": "sha256-EtvYFdtx3ZCfnNQEUdHWPquk9ApUdtf/uutEqyYX0sQ=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "e37d98ca1159538fdb9ca8336865870bf2eb2a47",
+        "rev": "e03c434eb3a3c81f481336c28462fbf34542efa9",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
         "ref": "main-0.4",
         "repo": "holonix",
+        "type": "github"
+      }
+    },
+    "kitsune2": {
+      "inputs": {
+        "crane": [
+          "crane"
+        ],
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1741125600,
+        "narHash": "sha256-XXkWi2lk0c7CVErONDt/YcHXoRjDV2GhOoOe4okaO7E=",
+        "owner": "holochain",
+        "repo": "kitsune2",
+        "rev": "39c6ecf0829161a443d767312cc62670f5dac80d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "v0.0.1-alpha6",
+        "repo": "kitsune2",
         "type": "github"
       }
     },
@@ -170,11 +214,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739824009,
-        "narHash": "sha256-fcNrCMUWVLMG3gKC5M9CBqVOAnJtyRvGPxptQFl5mVg=",
+        "lastModified": 1736429655,
+        "narHash": "sha256-BwMekRuVlSB9C0QgwKMICiJ5EVbLGjfe4qyueyNQyGI=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "e5130d37369bfa600144c2424270c96f0ef0e11d",
+        "rev": "0621e47bd95542b8e1ce2ee2d65d6a1f887a13ce",
         "type": "github"
       },
       "original": {
@@ -186,11 +230,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740865531,
-        "narHash": "sha256-h00vGIh/jxcGl8aWdfnVRD74KuLpyY3mZgMFMy7iKIc=",
+        "lastModified": 1739206421,
+        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ef6c425980847c78a80d759abc476e941a9bf42",
+        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
         "type": "github"
       },
       "original": {
@@ -201,6 +245,18 @@
       }
     },
     "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+      }
+    },
+    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1740872140,
         "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
@@ -218,24 +274,46 @@
         "crane": "crane",
         "flake-parts": "flake-parts",
         "holonix": "holonix",
+        "kitsune2": "kitsune2",
         "naersk": "naersk",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
+        "rust-overlay": "rust-overlay_2",
         "tryorama": "tryorama"
       }
     },
     "rust-overlay": {
       "inputs": {
         "nixpkgs": [
+          "kitsune2",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1740969088,
-        "narHash": "sha256-BajboqzFnDhxVT0SXTDKVJCKtFP96lZXccBlT/43mao=",
+        "lastModified": 1741055476,
+        "narHash": "sha256-52vwEV0oS2lCnx3c/alOFGglujZTLmObit7K8VblnS8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "20fdb02098fdda9a25a2939b975abdd7bc03f62d",
+        "rev": "aefb7017d710f150970299685e8d8b549d653649",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739327257,
+        "narHash": "sha256-rlGK8wxz/e50Z+PQRzuP+m03IrGkhcPGmgkBnkEZ9C8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e01f2c035b7b8a428c119b183f4cbc55f2eef07c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,14 @@
       };
     };
 
+    kitsune2 = {
+      url = "github:holochain/kitsune2?ref=v0.0.1-alpha6";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        crane.follows = "crane";
+      };
+    };
+
     tryorama = {
       url = "github:holochain/tryorama?ref=v0.17.0";
       inputs = {
@@ -74,7 +82,7 @@
         ];
 
         devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
+          packages = [
             pkgs.influxdb2-cli
             pkgs.influxdb2-server
             # TODO https://docs.influxdata.com/telegraf/v1/install/#ntp
@@ -90,6 +98,7 @@
             customHolochain
             inputs'.holonix.packages.lair-keystore
             inputs'.holonix.packages.hn-introspect
+            inputs'.kitsune2.packages.bootstrap-srv
             inputs'.tryorama.packages.trycp-server
             inputs'.amber.packages.default
           ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
@@ -108,6 +117,9 @@
 
         devShells.ci = pkgs.mkShell {
           packages = [
+            pkgs.cmake
+            pkgs.perl
+            pkgs.rustPlatform.bindgenHook
             pkgs.shellcheck
             pkgs.statix
             pkgs.taplo
@@ -115,6 +127,7 @@
             config.rustHelper.rust
             customHolochain
             inputs'.holonix.packages.lair-keystore
+            inputs'.kitsune2.packages.bootstrap-srv
             inputs'.tryorama.packages.trycp-server
           ];
         };

--- a/framework/instruments/src/lib.rs
+++ b/framework/instruments/src/lib.rs
@@ -3,7 +3,6 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::runtime::Runtime;
 use wind_tunnel_core::prelude::DelegatedShutdownListener;
 
 mod report;
@@ -53,7 +52,7 @@ impl ReportConfig {
 
     pub fn init_reporter(
         self,
-        runtime: &Runtime,
+        runtime: &tokio::runtime::Handle,
         shutdown_listener: DelegatedShutdownListener,
     ) -> anyhow::Result<Reporter> {
         if self.enable_influx_client && self.enable_influx_file {

--- a/framework/instruments/src/report/influx_client_reporter.rs
+++ b/framework/instruments/src/report/influx_client_reporter.rs
@@ -7,7 +7,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::report::influx_reporter_base::InfluxReporterBase;
-use tokio::runtime::Runtime;
 use tokio::select;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinHandle;
@@ -25,7 +24,7 @@ pub struct InfluxClientReportCollector {
 
 impl InfluxClientReportCollector {
     pub fn new(
-        runtime: &Runtime,
+        runtime: &tokio::runtime::Handle,
         shutdown_listener: DelegatedShutdownListener,
         run_id: String,
         scenario_name: String,
@@ -73,7 +72,7 @@ impl ReportCollector for InfluxClientReportCollector {
 }
 
 fn start_metrics_write_task(
-    runtime: &Runtime,
+    runtime: &tokio::runtime::Handle,
     mut shutdown_listener: DelegatedShutdownListener,
     client: Client,
     flush_complete: Arc<AtomicBool>,

--- a/framework/instruments/src/report/influx_file_reporter.rs
+++ b/framework/instruments/src/report/influx_file_reporter.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
-use tokio::runtime::Runtime;
 use tokio::select;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinHandle;
@@ -28,7 +27,7 @@ pub struct InfluxFileReportCollector {
 
 impl InfluxFileReportCollector {
     pub fn new(
-        runtime: &Runtime,
+        runtime: &tokio::runtime::Handle,
         shutdown_listener: DelegatedShutdownListener,
         dir: PathBuf,
         run_id: String,
@@ -70,7 +69,7 @@ impl ReportCollector for InfluxFileReportCollector {
 }
 
 fn start_metrics_file_write_task(
-    runtime: &Runtime,
+    runtime: &tokio::runtime::Handle,
     mut shutdown_listener: DelegatedShutdownListener,
     dir: PathBuf,
     scenario_name: String,

--- a/framework/runner/src/executor.rs
+++ b/framework/runner/src/executor.rs
@@ -8,7 +8,7 @@ use wind_tunnel_core::prelude::{ShutdownHandle, ShutdownSignalError};
 /// cancellation if they could be long-running.
 ///
 /// You should not need to construct this type yourself. It is constructed by the Wind Tunnel runner
-/// during as part of the [run](crate::run::run) function. You get a handle to it from the [RunnerContext](crate::context::RunnerContext).
+/// as part of the [run](crate::run::run) function. You get a handle to it from the [RunnerContext](crate::context::RunnerContext).
 #[derive(Debug)]
 pub struct Executor {
     runtime: tokio::runtime::Runtime,

--- a/framework/runner/src/run.rs
+++ b/framework/runner/src/run.rs
@@ -82,7 +82,9 @@ pub fn run<RV: UserValuesConstraint, V: UserValuesConstraint>(
             }
         }
 
-        Arc::new(report_config.init_reporter(&runtime, report_shutdown_handle.new_listener())?)
+        Arc::new(
+            report_config.init_reporter(runtime.handle(), report_shutdown_handle.new_listener())?,
+        )
     };
     let executor = Arc::new(Executor::new(runtime, shutdown_handle.clone()));
     let mut runner_context = RunnerContext::new(

--- a/happ_builder/src/lib.rs
+++ b/happ_builder/src/lib.rs
@@ -405,9 +405,7 @@ fn print_rerun_for_package(package_dir: &Path) {
     walkdir::WalkDir::new(package_dir.join("src"))
         .into_iter()
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_type().is_file() && e.path().extension().map_or(false, |ext| ext == "rs")
-        })
+        .filter(|e| e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "rs"))
         .for_each(|e| println!("cargo:rerun-if-changed={}", e.path().display()));
 }
 

--- a/nix/modules/workspace.nix
+++ b/nix/modules/workspace.nix
@@ -23,6 +23,8 @@ let
 
     cargoExtraArgs = "--locked --workspace";
     SKIP_HAPP_BUILD = "1";
+    # Needed to build datachannel-sys
+    LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
 
     buildInputs = with pkgs; [
       # Some Holochain crates link against openssl
@@ -31,12 +33,20 @@ let
     ];
 
     nativeBuildInputs = with pkgs; [
+      # To build datachannel-sys
+      cmake
+      libclang.lib
+      clang
       # To build openssl-sys
       perl
       pkg-config
       # Because the holochain_client depends on Kitsune/tx5
       go
     ];
+
+    # Tests on CI are run in a separate step. Unit tests for kitsune involve WebRTC, which
+    # opens UDP ports which is not possible in the crane build environment.
+    doCheck = false;
   };
 
   cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {

--- a/scenarios/kitsune_continuous_flow/Cargo.toml
+++ b/scenarios/kitsune_continuous_flow/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "kitsune_continuous_flow"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+tokio = { workspace = true }
+
+kitsune_wind_tunnel_runner = { workspace = true }
+
+[lints]
+workspace = true
+
+# This key must be present for the happ builder to work,
+# but it's empty since kitsune scenarios do not require dnas or happs.
+[package.metadata]

--- a/scenarios/kitsune_continuous_flow/src/main.rs
+++ b/scenarios/kitsune_continuous_flow/src/main.rs
@@ -1,0 +1,36 @@
+use kitsune_wind_tunnel_runner::prelude::*;
+use std::time::Duration;
+
+fn agent_setup(ctx: &mut AgentContext<KitsuneRunnerContext, KitsuneAgentContext>) -> HookResult {
+    create_chatter(ctx)?;
+    join_chatter_space(ctx)
+}
+
+fn behavior(
+    ctx: &mut AgentContext<KitsuneRunnerContext, KitsuneAgentContext>,
+) -> anyhow::Result<()> {
+    let message = format!(
+        "message_{}_{}",
+        ctx.agent_index(),
+        std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("time went backwards")
+            .as_millis()
+    );
+    say(ctx, &message)?;
+    ctx.runner_context().executor().execute_in_place(async {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        Ok(())
+    })
+}
+
+fn main() -> WindTunnelResult<()> {
+    let builder =
+        KitsuneScenarioDefinitionBuilder::<KitsuneRunnerContext, KitsuneAgentContext>::new_with_init(
+            "kitsune",
+        )?.into_std()
+        .use_agent_setup(agent_setup)
+        .use_agent_behaviour(behavior);
+    run(builder)?;
+    Ok(())
+}

--- a/scripts/format-yaml.sh
+++ b/scripts/format-yaml.sh
@@ -6,4 +6,4 @@ set -eux
 
 EXTRA_ARG=${1:-}
 
-yamlfmt "$EXTRA_ARG" .
+yamlfmt -gitignore_excludes "$EXTRA_ARG" .


### PR DESCRIPTION
This looks like a huge PR, ~~but about half of it is the op store implementation, and that is largely doing the same as the memory op store. I haven't just copied that over, because I wanted to understand what I was doing, but it turned out nearly identical.~~, and it no longer has the replicated op store implementation, so it's just huge. Sorry! I'm stopping here and keep the rest for the scenario issue.

I need to update the bootstrap server to run on a set port first to enable the test on CI.

resolves #137 