### PR TITLE
feat: Allow overriding `run_id` and use it as the `network_seed`

### DIFF
--- a/bindings/kitsune_runner/src/cli.rs
+++ b/bindings/kitsune_runner/src/cli.rs
@@ -55,6 +55,12 @@ pub struct WindTunnelKitsuneScenarioCli {
     /// The reporter to use.
     #[arg(long, value_enum, default_value_t = ReporterOpt::InMemory)]
     pub reporter: ReporterOpt,
+
+    /// Set the ID of this run
+    ///
+    /// If not set, a random ID is used.
+    #[arg(long, short)]
+    pub run_id: Option<String>,
 }
 
 impl TryInto<WindTunnelScenarioCli> for WindTunnelKitsuneScenarioCli {
@@ -73,6 +79,7 @@ impl TryInto<WindTunnelScenarioCli> for WindTunnelKitsuneScenarioCli {
             soak: self.soak,
             no_progress: self.no_progress,
             reporter: self.reporter,
+            run_id: self.run_id,
         })
     }
 }

--- a/bindings/runner/src/common.rs
+++ b/bindings/runner/src/common.rs
@@ -143,6 +143,7 @@ where
     let app_ws_url = ctx.runner_context().get().app_ws_url();
     let installed_app_id = installed_app_id_for_agent(ctx);
     let reporter = ctx.runner_context().reporter();
+    let run_id = ctx.runner_context().get_run_id().to_string();
 
     let (installed_app_id, cell_id, app_client) = ctx
         .runner_context()
@@ -165,7 +166,7 @@ where
                     agent_key: Some(key),
                     installed_app_id: Some(installed_app_id.clone()),
                     roles_settings: None,
-                    network_seed: None,
+                    network_seed: Some(run_id),
                     ignore_genesis_failure: false,
                     allow_throwaway_random_agent_key: false,
                 })

--- a/bindings/trycp_runner/src/cli.rs
+++ b/bindings/trycp_runner/src/cli.rs
@@ -57,6 +57,12 @@ pub struct WindTunnelTryCPScenarioCli {
     /// The reporter to use.
     #[arg(long, value_enum, default_value_t = ReporterOpt::InMemory)]
     pub reporter: ReporterOpt,
+
+    /// Set the ID of this run
+    ///
+    /// If not set, a random ID is used.
+    #[arg(long, short)]
+    pub run_id: Option<String>,
 }
 
 impl TryInto<WindTunnelScenarioCli> for WindTunnelTryCPScenarioCli {
@@ -94,7 +100,7 @@ impl TryInto<WindTunnelScenarioCli> for WindTunnelTryCPScenarioCli {
             soak: self.soak,
             no_progress: self.no_progress,
             reporter: self.reporter,
-            run_id: None, // Setting run ID not needed because runs are centrally controlled by TryCP
+            run_id: self.run_id,
         })
     }
 }

--- a/bindings/trycp_runner/src/cli.rs
+++ b/bindings/trycp_runner/src/cli.rs
@@ -94,7 +94,7 @@ impl TryInto<WindTunnelScenarioCli> for WindTunnelTryCPScenarioCli {
             soak: self.soak,
             no_progress: self.no_progress,
             reporter: self.reporter,
-            run_id: None,
+            run_id: None, // Setting run ID not needed because runs are centrally controlled by TryCP
         })
     }
 }

--- a/bindings/trycp_runner/src/cli.rs
+++ b/bindings/trycp_runner/src/cli.rs
@@ -94,6 +94,7 @@ impl TryInto<WindTunnelScenarioCli> for WindTunnelTryCPScenarioCli {
             soak: self.soak,
             no_progress: self.no_progress,
             reporter: self.reporter,
+            run_id: None,
         })
     }
 }

--- a/framework/runner/src/cli.rs
+++ b/framework/runner/src/cli.rs
@@ -43,6 +43,12 @@ pub struct WindTunnelScenarioCli {
     /// The reporter to use.
     #[arg(long, value_enum, default_value_t = ReporterOpt::InMemory)]
     pub reporter: ReporterOpt,
+
+    /// Set the ID of this run
+    ///
+    /// If not set, a random ID is used.
+    #[arg(long, short)]
+    pub run_id: Option<String>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]

--- a/framework/runner/src/definition.rs
+++ b/framework/runner/src/definition.rs
@@ -51,6 +51,7 @@ pub struct ScenarioDefinition<RV: UserValuesConstraint, V: UserValuesConstraint>
     pub(crate) agent_behaviour: HashMap<String, AgentHookMut<RV, V>>,
     pub(crate) teardown_agent_fn: Option<AgentHookMut<RV, V>>,
     pub(crate) teardown_fn: Option<GlobalHook<RV>>,
+    pub(crate) run_id: String,
 }
 
 impl<RV: UserValuesConstraint, V: UserValuesConstraint> ScenarioDefinition<RV, V> {
@@ -208,6 +209,8 @@ impl<RV: UserValuesConstraint, V: UserValuesConstraint> ScenarioDefinitionBuilde
             ));
         }
 
+        let run_id = self.cli.run_id.clone().unwrap_or_else(|| nanoid::nanoid!());
+
         Ok(ScenarioDefinition {
             name: self.name,
             assigned_behaviours: build_assigned_behaviours(&self.cli, resolved_agent_count)?,
@@ -221,6 +224,7 @@ impl<RV: UserValuesConstraint, V: UserValuesConstraint> ScenarioDefinitionBuilde
             agent_behaviour: self.agent_behaviour,
             teardown_agent_fn: self.teardown_agent_fn,
             teardown_fn: self.teardown_fn,
+            run_id,
         })
     }
 }
@@ -269,6 +273,7 @@ mod tests {
                 soak: false,
                 no_progress: true,
                 reporter: ReporterOpt::Noop,
+                run_id: None,
             },
             5,
         )
@@ -290,6 +295,7 @@ mod tests {
                 soak: false,
                 no_progress: true,
                 reporter: ReporterOpt::Noop,
+                run_id: None,
             },
             5,
         )
@@ -311,6 +317,7 @@ mod tests {
                 soak: false,
                 no_progress: true,
                 reporter: ReporterOpt::Noop,
+                run_id: None,
             },
             5,
         )
@@ -334,6 +341,7 @@ mod tests {
                 soak: false,
                 no_progress: true,
                 reporter: ReporterOpt::Noop,
+                run_id: None,
             },
             5,
         );

--- a/framework/runner/src/run.rs
+++ b/framework/runner/src/run.rs
@@ -20,15 +20,14 @@ use wind_tunnel_summary_model::append_run_summary;
 pub fn run<RV: UserValuesConstraint, V: UserValuesConstraint>(
     definition: ScenarioDefinitionBuilder<RV, V>,
 ) -> anyhow::Result<usize> {
-    let run_id = nanoid::nanoid!();
-    println!("#RunId: [{}]", run_id);
-
     let definition = definition.build()?;
+
+    println!("#RunId: [{}]", definition.run_id);
 
     // Create the summary for the run. This is used to link the run with the report and build a
     // summary from the metrics after the run has completed.
     let mut summary = wind_tunnel_summary_model::RunSummary::new(
-        run_id.clone(),
+        definition.run_id.clone(),
         definition.name.clone(),
         chrono::Utc::now().timestamp(),
         definition.duration_s,
@@ -61,7 +60,8 @@ pub fn run<RV: UserValuesConstraint, V: UserValuesConstraint>(
 
     let reporter = {
         let _h = runtime.handle().enter();
-        let mut report_config = ReportConfig::new(run_id.clone(), definition.name.clone());
+        let mut report_config =
+            ReportConfig::new(definition.run_id.clone(), definition.name.clone());
 
         match definition.reporter {
             ReporterOpt::InMemory => {
@@ -91,7 +91,7 @@ pub fn run<RV: UserValuesConstraint, V: UserValuesConstraint>(
         executor,
         reporter,
         shutdown_handle.clone(),
-        run_id.clone(),
+        definition.run_id.clone(),
         definition.connection_string.clone(),
     );
 
@@ -248,7 +248,7 @@ pub fn run<RV: UserValuesConstraint, V: UserValuesConstraint>(
         log::error!("Failed to append run summary: {:?}", e);
     }
 
-    println!("#RunId: [{}]", run_id);
+    println!("#RunId: [{}]", definition.run_id);
 
     Ok(agents_run_to_completion.load(std::sync::atomic::Ordering::Acquire))
 }

--- a/framework/runner/tests/hook_error_handling.rs
+++ b/framework/runner/tests/hook_error_handling.rs
@@ -26,6 +26,7 @@ fn sample_cli_cfg() -> WindTunnelScenarioCli {
         soak: false,
         no_progress: true,
         reporter: ReporterOpt::Noop,
+        run_id: None,
     }
 }
 


### PR DESCRIPTION
Being able to set the run ID allows multiple scenarios to be run with the same ID. One example is when testing a single scenario on multiple conductors with the goal of consolidating the logs into a single run.

Using the run ID as the network seed means that each run will have a unique network and will not interfere with other runs, and all conductors running a scenario as a single run will share a network seed.