### PR TITLE
docs: update changelog with missing entries and fix mentioned versions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### Summary
+
+
+
+### TODO:
+- [ ] CHANGELOGs updated with appropriate info
+- [ ] All code changes are reflected in docs, including module-level docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   broadcast channel that it uses internally. Shutdown failures used to panic but it a `ShutdownHandle` happens to not
   have any subscribers then that should not be considered a fatal error. It will now log a warning instead.
 - Metrics now automatically include `run_id` and `scenario_name` tags.
-- Update `trycp_client` and `trycp_api` dependencies to `v0.17.0-dev.6`. [#117](https://github.com/holochain/wind-tunnel/pull/117)
+- Update `trycp_client` and `trycp_api` dependencies to `v0.17.0`. [#117](https://github.com/holochain/wind-tunnel/pull/117)
 - When making zome calls with the TryCP client bindings, the `agent` is now reported on the metrics, taken from the target
   cell_id for the call. For the wrapped `holochain_client`, this is only done when the call target is `CellId`. Or in 
   other words, the `agent` is not reported when calling a clone cell.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated to Holochain `v0.4.2`
-- Updated to new Holochain client version 0.5.0-alpha.4 which allowed `&mut self` to be replaced with `&self` in admin
-  and app instrumented websockets.
+- Updated to new Holochain client version `v0.6.2`
+- Replace `&mut self` with `&self` in admin and app instrumented websockets.
 - `ShutdownHandle` now hides its implementation. It works the same way that it did but you can no longer access the 
   broadcast channel that it uses internally. Shutdown failures used to panic but it a `ShutdownHandle` happens to not
   have any subscribers then that should not be considered a fatal error. It will now log a warning instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   building the scenario if they do not match. [#122](https://github.com/holochain/wind-tunnel/pull/122)
 
 ### Changed
-- Updated to Holochain 0.4.0
+- Updated to Holochain `v0.4.2`
 - Updated to new Holochain client version 0.5.0-alpha.4 which allowed `&mut self` to be replaced with `&self` in admin
   and app instrumented websockets.
 - `ShutdownHandle` now hides its implementation. It works the same way that it did but you can no longer access the 
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All metrics are now reported in seconds, as an `f64`. There were some types still using milliseconds which made reporting
   across scenarios more complex.
 - Increased TryCP test scenario duration to 30s in CI [Test Workflow](.github/workflows/test.yaml).
+- Use the new `AppBundleSource::Bytes` variant to bundle scenarios [#152](https://github.com/holochain/wind-tunnel/pull/152)
 
 ### Deprecated
 ### Removed


### PR DESCRIPTION
I forgot to update the changelog as part of #152 and I also saw that some of the versions mentioned in the "Unreleased" section were now outdated, so I updated them.