### PR TITLE
Kitsune op store returns all processed incoming op ids

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -259,7 +259,7 @@ jobs:
           set -x
 
           # Start local bootstrap and signal server
-          nix develop .#ci -c bash -c "kitsune2-bootstrap-srv --listen 127.0.0.1:30000 &"
+          nix develop .#kitsune -c bash -c "kitsune2-bootstrap-srv --listen 127.0.0.1:30000 &"
 
           # Run the scenario
           RUST_LOG=warn cargo run -p kitsune_continuous_flow -- --bootstrap-server-url http://127.0.0.1:30000 --signal-server-url ws://127.0.0.1:30000 --duration 15 --agents 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is less than the passed `min_required_agents`. Can be overridden with the `MIN_REQUIRED_AGENTS` environment variable.
 - Check that the scenarios have a cargo package name that matches the directory name used by Nix packages. Panic when
   building the scenario if they do not match. [#122](https://github.com/holochain/wind-tunnel/pull/122)
+- Nix dev shell for kitsune scenarios.
 
 ### Changed
 - Updated to Holochain `v0.4.2`
@@ -41,11 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   across scenarios more complex.
 - Increased TryCP test scenario duration to 30s in CI [Test Workflow](.github/workflows/test.yaml).
 - Use the new `AppBundleSource::Bytes` variant to bundle scenarios [#152](https://github.com/holochain/wind-tunnel/pull/152)
+- Test workflow uses kitsune dev shell for kitsune scenario.
 
 ### Deprecated
 ### Removed
 ### Fixed
 - Run the TryCP scenarios in the [Performance Workflow](.github/workflows/performance.yaml) on the Holo Ports defined in [targets.yaml](targets.yaml). [#117](https://github.com/holochain/wind-tunnel/pull/117)
+- Fix Kitsune op store to always return all processed op ids. Previously ops processed multiple times would not be removed from the request queue. Duplicate ops are still not considered for reporting.
 
 ### Security
 

--- a/flake.nix
+++ b/flake.nix
@@ -81,57 +81,68 @@
           ./nix/modules/zomes.nix
         ];
 
-        devShells.default = pkgs.mkShell {
-          packages = [
-            pkgs.influxdb2-cli
-            pkgs.influxdb2-server
-            # TODO https://docs.influxdata.com/telegraf/v1/install/#ntp
-            pkgs.telegraf
-            pkgs.yq
-            pkgs.httpie
-            pkgs.shellcheck
-            pkgs.statix
-            pkgs.taplo
-            pkgs.yamlfmt
-            pkgs.perl
-            pkgs.cmake
-            pkgs.rustPlatform.bindgenHook
-            config.rustHelper.rust
-            customHolochain
-            inputs'.holonix.packages.lair-keystore
-            inputs'.holonix.packages.hn-introspect
-            inputs'.kitsune2.packages.bootstrap-srv
-            inputs'.tryorama.packages.trycp-server
-            inputs'.amber.packages.default
-          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-            pkgs.darwin.apple_sdk.frameworks.Security
-            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-            pkgs.darwin.apple_sdk.frameworks.CoreFoundation
-          ];
+        devShells = {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.influxdb2-cli
+              pkgs.influxdb2-server
+              # TODO https://docs.influxdata.com/telegraf/v1/install/#ntp
+              pkgs.telegraf
+              pkgs.yq
+              pkgs.httpie
+              pkgs.shellcheck
+              pkgs.statix
+              pkgs.taplo
+              pkgs.yamlfmt
+              pkgs.perl
+              pkgs.cmake
+              pkgs.rustPlatform.bindgenHook
+              config.rustHelper.rust
+              customHolochain
+              inputs'.holonix.packages.lair-keystore
+              inputs'.holonix.packages.hn-introspect
+              inputs'.kitsune2.packages.bootstrap-srv
+              inputs'.tryorama.packages.trycp-server
+              inputs'.amber.packages.default
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.darwin.apple_sdk.frameworks.Security
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+              pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+            ];
 
-          shellHook = ''
-            source ./scripts/influx.sh
-            source ./scripts/telegraf.sh
-            source ./scripts/trycp.sh
-            source ./scripts/checks.sh
-          '';
-        };
+            shellHook = ''
+              source ./scripts/influx.sh
+              source ./scripts/telegraf.sh
+              source ./scripts/trycp.sh
+              source ./scripts/checks.sh
+            '';
+          };
 
-        devShells.ci = pkgs.mkShell {
-          packages = [
-            pkgs.cmake
-            pkgs.perl
-            pkgs.rustPlatform.bindgenHook
-            pkgs.shellcheck
-            pkgs.statix
-            pkgs.taplo
-            pkgs.yamlfmt
-            config.rustHelper.rust
-            customHolochain
-            inputs'.holonix.packages.lair-keystore
-            inputs'.kitsune2.packages.bootstrap-srv
-            inputs'.tryorama.packages.trycp-server
-          ];
+          ci = pkgs.mkShell {
+            packages = [
+              pkgs.cmake
+              pkgs.perl
+              pkgs.rustPlatform.bindgenHook
+              pkgs.shellcheck
+              pkgs.statix
+              pkgs.taplo
+              pkgs.yamlfmt
+              config.rustHelper.rust
+              customHolochain
+              inputs'.holonix.packages.lair-keystore
+              inputs'.kitsune2.packages.bootstrap-srv
+              inputs'.tryorama.packages.trycp-server
+            ];
+          };
+
+          kitsune = pkgs.mkShell {
+            packages = [
+              pkgs.cmake
+              pkgs.perl
+              pkgs.rustPlatform.bindgenHook
+              inputs'.kitsune2.packages.bootstrap-srv
+            ];
+          };
         };
 
         packages = {


### PR DESCRIPTION
### Summary
- Fix WT op store to always return all processed op ids. Previously ops processed multiple times would not be removed from the request queue. Duplicate ops are still not considered for reporting.
- Add nix dev shell for kitsune scenarios.
- CI workflow uses kitsune dev shell for kitsune scenario.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs