### PR TITLE
Enable former TryCP scenarios on Nomad cluster CI

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -18,6 +18,9 @@ jobs:
       # `required-nodes` defaults to `1` if not provided.
       matrix:
         scenario-name:
+          - remote_call_rate
+          - remote_signals
+          - two_party_countersigning
           - first_call
           - local_signals
           - single_write_many_read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Updated to Holochain `v0.5.2`
 - Updated to new Holochain client version `v0.7.0`
+- Enable the former TryCP scenarios on the Nomad cluster CI: remote_call_rate, remote_signals and two_party_countersigning.
 
 ### Added
 - Exposed `on_signal` from the app websocket in the instrumented websocket.

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ found in the Holochain shared vault of the password manager under `Nomad Server 
 
 Enter the token (or use auto-fill) to sign in at <https://nomad-server-01.holochain.org:4646/ui/settings/tokens>.
 
-You can now view and recent or running jobs at <https://nomad-server-01.holochain.org:4646/ui/jobs>.
+You can now view any recent or running jobs at <https://nomad-server-01.holochain.org:4646/ui/jobs>.
 
 ###### Running Scenarios from the Command-Line
 

--- a/nomad/var_files/remote_call_rate.vars
+++ b/nomad/var_files/remote_call_rate.vars
@@ -1,0 +1,3 @@
+scenario-name = "remote_call_rate"
+duration = 300
+agents-per-node = 2

--- a/nomad/var_files/remote_signals.vars
+++ b/nomad/var_files/remote_signals.vars
@@ -1,0 +1,3 @@
+scenario-name = "remote_signals"
+agents-per-node = 2
+duration = 300

--- a/nomad/var_files/two_party_countersigning.vars
+++ b/nomad/var_files/two_party_countersigning.vars
@@ -1,0 +1,7 @@
+scenario-name = "two_party_countersigning"
+agents-per-node = 1
+behaviours = [
+    "initiate",
+    "participate",
+]
+duration = 300


### PR DESCRIPTION
### Summary

I ran multiple jobs of each scenario with success and checked results on InfluxDB.

resolves #162 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs