### PR TITLE
ci: add missing CACHIX_AUTH_TOKEN env to cachix push step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,8 @@ jobs:
       # do run out of disk space, then at least we've captured that big piece in the
       # cache and can just download it next time.
       - name: Cache CI shell
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: |
           nix develop --profile ci-profile -c true
           cachix push holochain-ci ci-profile


### PR DESCRIPTION
### Summary

The cachix token is not present in the push job so it fails: https://github.com/holochain/wind-tunnel/actions/runs/16260690774/job/45905106311

I think that it's previously passed because there has been nothing to push so it doesn't try.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs