### PR TITLE
feat: create a job per scenario in Nomad instead of a single job

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -18,12 +18,12 @@ jobs:
       # `required-nodes` defaults to `1` if not provided.
       matrix:
         scenario-name:
-          - remote_call_rate
-          - remote_signals
-          - two_party_countersigning
           - first_call
           - local_signals
+          - remote_call_rate
+          - remote_signals
           - single_write_many_read
+          - two_party_countersigning
           - write_query
           - write_read
           - write_validated
@@ -47,6 +47,10 @@ jobs:
         run: |
           nix bundle .#packages.x86_64-linux.${{ matrix.scenario-name }}
           cp ./${{ matrix.scenario-name }}-arx ./${{ matrix.scenario-name }}
+
+      - name: Build Nomad Job
+        run: |
+          nix develop --command ./nomad/generate_jobs.sh ${{ matrix.scenario-name }}
 
       - name: Upload bundle as artifact
         id: upload-bundle
@@ -93,6 +97,6 @@ jobs:
           NOMAD_VAR_scenario-url: ${{ steps.get-download-url.outputs.download-url }}
           NOMAD_VAR_run-id: ${{ github.run_id }}
         run: |-
-          nix run --impure --inputs-from . nixpkgs#nomad -- job run -var-file="nomad/var_files/${{ matrix.job-name || matrix.scenario-name }}.vars" nomad/run_scenario.nomad.hcl
+          nix run --impure --inputs-from . nixpkgs#nomad -- job run nomad/jobs/${{ matrix.job-name || matrix.scenario-name }}.nomad.hcl
 
           echo "Ran ${{ matrix.job-name }} with run ID ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ summariser-report-*.json
 
 # A symlink to the output directory of nix builds
 result
+
+# auto-generated jobs for nomad
+nomad/jobs/*.nomad.hcl

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ For more advanced scenarios or for distributed tests, this is not appropriate!
 #### Running scenarios
 
 Each scenario is expected to provide a README.md with at least:
+
 - A description of the scenario and what it is testing for.
 - A suggested command or commands to run the scenario, with justification for the configuration used.
 
@@ -386,6 +387,7 @@ Then you can move to writing and running the scenario.
 #### Standard Wind Tunnel tests
 
 For standard Wind Tunnel tests - start a sandbox for testing:
+
 ```bash
 hc s clean && echo "1234" | hc s --piped create && echo "1234" | hc s --piped -f 8888 run
 ```
@@ -430,11 +432,12 @@ Replace `app_install` with the name of the scenario that you want to run.
 Once the scenario is built you can run the Nomad job with:
 
 ```bash
-nomad job run -address=http://localhost:4646 -var-file=nomad/var_files/app_install_minimal.vars -var scenario-url=result/bin/app_install -var reporter=in-memory nomad/run_scenario.nomad.hcl
+nomad job run -address=http://localhost:4646 -var scenario-url=result/bin/app_install -var reporter=in-memory nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
+All the jobs are in the `nomad/jobs` directory, so you can replace `app_install_minimal` with the name of the job you want to run.
+
 - `-address` sets Nomad to talk to the locally running instance and not the dedicated Wind Tunnel cluster one.
-- `-var-file` should point to the var file, in `nomad/var_files`, of the scenario you want to run.
 - `-var scenario-url=...` provides the path to the scenario binary that you built in the previous step.
 - `-var reporter=in-memory` sets the reporter type to print to `stdout` instead of writing an InfluxDB metrics file.
 
@@ -446,7 +449,7 @@ nomad job run -address=http://localhost:4646 -var-file=nomad/var_files/app_insta
 You can also override existing and omitted variables with the `-var` flag. For example, to set the duration (in seconds) use:
 
 ```bash
-nomad job run -address=http://localhost:4646 -var-file=nomad/var_files/app_install_minimal.vars -var scenario-url=result/bin/app_install -var reporter=in-memory -var duration=300 nomad/run_scenario.nomad.hcl
+nomad job run -address=http://localhost:4646 -var scenario-url=result/bin/app_install -var reporter=in-memory -var duration=300 nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
 > [!Note]
@@ -580,11 +583,13 @@ If your bootstrap and signal servers run under a different port, adapt the comma
 ### Published crates
 
 Framework crates:
+
 - [![crates.io](https://img.shields.io/crates/v/wind_tunnel_core)](https://crates.io/crates/wind_tunnel_core) Core functionality for use by other Wind Tunnel crates - [wind_tunnel_core](https://github.com/holochain/wind-tunnel/tree/main/framework/core)
 - [![crates.io](https://img.shields.io/crates/v/wind_tunnel_instruments)](https://crates.io/crates/wind_tunnel_instruments) Instruments for measuring performance with Wind Tunnel - [wind_tunnel_instruments](https://github.com/holochain/wind-tunnel/tree/main/framework/instruments)
 - [![crates.io](https://img.shields.io/crates/v/wind_tunnel_instruments_derive)](https://crates.io/crates/wind_tunnel_instruments_derive) Derive macros for the wind_tunnel_instruments crate - [wind_tunnel_instruments_derive](https://github.com/holochain/wind-tunnel/tree/main/framework/instruments_derive)
 - [![crates.io](https://img.shields.io/crates/v/wind_tunnel_runner)](https://crates.io/crates/wind_tunnel_runner) The Wind Tunnel runner - [wind_tunnel_runner](https://github.com/holochain/wind-tunnel/tree/main/framework/runner)
 
 Bindings crates for Holochain:
+
 - [![crates.io](https://img.shields.io/crates/v/holochain_client_instrumented)](https://crates.io/crates/holochain_client_instrumented) An instrumented wrapper around the holochain_client - [holochain_client_instrumented](https://github.com/holochain/wind-tunnel/tree/main/bindings/client)
 - [![crates.io](https://img.shields.io/crates/v/holochain_wind_tunnel_runner)](https://crates.io/crates/holochain_wind_tunnel_runner) Customises the wind_tunnel_runner for Holochain testing - [holochain_wind_tunnel_runner](https://github.com/holochain/wind-tunnel/tree/main/bindings/runner)

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
             # The packages required in most devShells
             commonPackages = [
               pkgs.cmake
+              pkgs.gomplate
               pkgs.perl
               pkgs.rustPlatform.bindgenHook
               pkgs.shellcheck

--- a/nomad/README.md
+++ b/nomad/README.md
@@ -1,0 +1,45 @@
+# Nomad Jobs
+
+## Create new jobs
+
+In order to define new jobs, you just need to create a new vars file in the `./vars` directory with a JSON file with the name of the job you want to create. For example, if you want to create a job for the `app_install` scenario, you can create a file named `app_install.json` in the `nomad/vars` directory.
+
+### Vars file syntax
+
+A simple Example:
+
+```json
+{
+  "scenario_name": "app_install",
+  "behaviours": [
+    "large"
+  ]
+}
+```
+
+The following variables are available:
+
+- `scenario_name`: The name of the scenario you want to run. (**required**)
+- `behaviours`: A list of behaviours to apply to the scenario. (_optional_, defaults to `[""]`)
+- `connection_string`: The connection string to the Holochain conductor. (_optional_, defaults to `ws://localhost:8888`)
+- `run_id`: The ID of the run to distinguish it from other runs. (_optional_, defaults to `null`)
+- `agents_per_node`: The number of agents per node. (_optional_, defaults to `1`)
+- `min_agents`: The minimum number of agents to run the scenario with. (_optional_, defaults to `2`)
+- `duration`: The duration of the scenario in seconds. (_optional_, defaults to `300`)
+- `reporter`: The reporter type to use. (_optional_, defaults to `influx-file`)
+
+## Generate Nomad Jobs
+
+Once you have created the vars file, you can generate the Nomad job file by running the following command:
+
+```bash
+./nomad/generate_jobs.sh
+```
+
+This will generate the nomad job files in the `nomad/jobs` directory. The job files will be named after the scenario name, with the `.nomad.hcl` extension.
+
+Mind that in order to generate the jobs, you need to have `gomplate` installed. You can use the one provided by nix shell in this repository or download the latest version from the [gomplate releases page](https://github.com/hairyhenderson/gomplate/releases).
+
+## Jobs template
+
+Currently, all the jobs are generated from the same template, which is located in `nomad/run_scenario.tpl.hcl`. This template uses the variables defined in the vars file to generate the Nomad job file.

--- a/nomad/generate_jobs.sh
+++ b/nomad/generate_jobs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+generate_job() {
+  local var_file="$1"
+  local job_file="$2"
+  gomplate \
+    -f "$TEMPLATE" \
+    -o "$job_file" \
+    -d vars="$var_file"
+
+  echo "Generated job file: $job_file"
+}
+
+BASEDIR="$(dirname "$0")"
+VARS_DIR="$BASEDIR/vars"
+JOBS_DIR="$BASEDIR/jobs"
+TEMPLATE="$BASEDIR/run_scenario.tpl.hcl"
+
+mkdir -p "$JOBS_DIR"
+rm -rf "$JOBS_DIR"/*.nomad.hcl || true
+
+GOMPLATE=$(command -v gomplate || echo "gomplate")
+if [ -z "$GOMPLATE" ]; then
+  echo "gomplate is not installed. Please install it to generate Nomad jobs."
+  echo "You can install gomplate from the release page: <https://github.com/hairyhenderson/gomplate/releases>"
+  exit 1
+fi
+
+JOB_NAME="$1"
+
+# generate all
+if [ -z "$JOB_NAME" ]; then
+    # iter files in vars directory
+    for VAR_FILE in "$VARS_DIR"/*.json; do
+        BASENAME=$(basename "$VAR_FILE" .json)
+        JOB_FILE="$JOBS_DIR/$BASENAME.nomad.hcl"
+        generate_job "$VAR_FILE" "$JOB_FILE"
+    done
+else
+    # generate specific job
+    VAR_FILE="$VARS_DIR/$JOB_NAME.json"
+    if [ ! -f "$VAR_FILE" ]; then
+        echo "Variable file for job '$JOB_NAME' does not exist: $VAR_FILE"
+        exit 1
+    fi
+    JOB_FILE="$JOBS_DIR/$JOB_NAME.nomad.hcl"
+    generate_job "$VAR_FILE" "$JOB_FILE"
+fi

--- a/nomad/var_files/app_install_large.vars
+++ b/nomad/var_files/app_install_large.vars
@@ -1,2 +1,0 @@
-scenario-name = "app_install"
-behaviours = [ "large" ]

--- a/nomad/var_files/app_install_minimal.vars
+++ b/nomad/var_files/app_install_minimal.vars
@@ -1,2 +1,0 @@
-scenario-name = "app_install"
-behaviours = [ "minimal" ]

--- a/nomad/var_files/dht_sync_lag.vars
+++ b/nomad/var_files/dht_sync_lag.vars
@@ -1,6 +1,0 @@
-scenario-name = "dht_sync_lag"
-duration = 180
-behaviours = [
-  "write",
-  "record_lag",
-]

--- a/nomad/var_files/first_call.vars
+++ b/nomad/var_files/first_call.vars
@@ -1,1 +1,0 @@
-scenario-name = "first_call"

--- a/nomad/var_files/local_signals.vars
+++ b/nomad/var_files/local_signals.vars
@@ -1,1 +1,0 @@
-scenario-name = "local_signals"

--- a/nomad/var_files/remote_call_rate.vars
+++ b/nomad/var_files/remote_call_rate.vars
@@ -1,3 +1,0 @@
-scenario-name = "remote_call_rate"
-duration = 300
-agents-per-node = 2

--- a/nomad/var_files/remote_signals.vars
+++ b/nomad/var_files/remote_signals.vars
@@ -1,3 +1,0 @@
-scenario-name = "remote_signals"
-agents-per-node = 2
-duration = 300

--- a/nomad/var_files/single_write_many_read.vars
+++ b/nomad/var_files/single_write_many_read.vars
@@ -1,1 +1,0 @@
-scenario-name = "single_write_many_read"

--- a/nomad/var_files/two_party_countersigning.vars
+++ b/nomad/var_files/two_party_countersigning.vars
@@ -1,7 +1,0 @@
-scenario-name = "two_party_countersigning"
-agents-per-node = 1
-behaviours = [
-    "initiate",
-    "participate",
-]
-duration = 300

--- a/nomad/var_files/validation_receipts.vars
+++ b/nomad/var_files/validation_receipts.vars
@@ -1,4 +1,0 @@
-scenario-name = "validation_receipts"
-behaviours = [ "", "" ] # Run two nodes both with the default behaviour
-agents-per-node = 5
-min-agents = 10

--- a/nomad/var_files/write_query.vars
+++ b/nomad/var_files/write_query.vars
@@ -1,1 +1,0 @@
-scenario-name = "write_query"

--- a/nomad/var_files/write_read.vars
+++ b/nomad/var_files/write_read.vars
@@ -1,1 +1,0 @@
-scenario-name = "write_read"

--- a/nomad/var_files/write_validated.vars
+++ b/nomad/var_files/write_validated.vars
@@ -1,1 +1,0 @@
-scenario-name = "write_validated"

--- a/nomad/var_files/zome_call_single_value.vars
+++ b/nomad/var_files/zome_call_single_value.vars
@@ -1,1 +1,0 @@
-scenario-name = "zome_call_single_value"

--- a/nomad/vars/app_install_large.json
+++ b/nomad/vars/app_install_large.json
@@ -1,0 +1,6 @@
+{
+  "scenario_name": "app_install",
+  "behaviours": [
+    "large"
+  ]
+}

--- a/nomad/vars/app_install_minimal.json
+++ b/nomad/vars/app_install_minimal.json
@@ -1,0 +1,6 @@
+{
+  "scenario_name": "app_install",
+  "behaviours": [
+    "minimal"
+  ]
+}

--- a/nomad/vars/dht_sync_lag.json
+++ b/nomad/vars/dht_sync_lag.json
@@ -1,0 +1,8 @@
+{
+  "scenario_name": "dht_sync_lag",
+  "duration": 180,
+  "behaviours": [
+    "write",
+    "record_lag"
+  ]
+}

--- a/nomad/vars/first_call.json
+++ b/nomad/vars/first_call.json
@@ -1,0 +1,3 @@
+{
+  "scenario_name": "first_call"
+}

--- a/nomad/vars/local_signals.json
+++ b/nomad/vars/local_signals.json
@@ -1,0 +1,3 @@
+{
+  "scenario_name": "local_signals"
+}

--- a/nomad/vars/remote_call_rate.json
+++ b/nomad/vars/remote_call_rate.json
@@ -1,0 +1,5 @@
+{
+  "scenario_name": "remote_call_rate",
+  "duration": 300,
+  "agents_per_node": 2
+}

--- a/nomad/vars/remote_signals.json
+++ b/nomad/vars/remote_signals.json
@@ -1,0 +1,5 @@
+{
+  "scenario_name": "remote_signals",
+  "agents_per_node": 2,
+  "duration": 300
+}

--- a/nomad/vars/single_write_many_read.json
+++ b/nomad/vars/single_write_many_read.json
@@ -1,0 +1,3 @@
+{
+  "scenario_name": "single_write_many_read"
+}

--- a/nomad/vars/two_party_countersigning.json
+++ b/nomad/vars/two_party_countersigning.json
@@ -1,0 +1,9 @@
+{
+  "scenario_name": "two_party_countersigning",
+  "agents_per_node": 1,
+  "behaviours": [
+    "initiate",
+    "participate"
+  ],
+  "duration": 300
+}

--- a/nomad/vars/validation_receipts.json
+++ b/nomad/vars/validation_receipts.json
@@ -1,0 +1,9 @@
+{
+  "scenario_name": "validation_receipts",
+  "behaviours": [
+    "",
+    ""
+  ],
+  "agents_per_node": 5,
+  "min_agents": 10
+}

--- a/nomad/vars/write_query.json
+++ b/nomad/vars/write_query.json
@@ -1,0 +1,3 @@
+{
+  "scenario_name": "write_query"
+}

--- a/nomad/vars/write_read.json
+++ b/nomad/vars/write_read.json
@@ -1,0 +1,3 @@
+{
+  "scenario_name": "write_read"
+}

--- a/nomad/vars/write_validated.json
+++ b/nomad/vars/write_validated.json
@@ -1,0 +1,3 @@
+{
+  "scenario_name": "write_validated"
+}

--- a/nomad/vars/zome_call_single_value.json
+++ b/nomad/vars/zome_call_single_value.json
@@ -1,0 +1,3 @@
+{
+  "scenario_name": "zome_call_single_value"
+}


### PR DESCRIPTION
### Summary

closes: #163

- **feat: Created a Job per scenario using a template**
- **fix: quote variable names**

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow
[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it
can be merged, as these are used to generate the changelog_

---

# Nomad Jobs

## Create new jobs

In order to define new jobs, you just need to create a new vars file in the `./vars` directory with a JSON file with the name of the job you want to create. For example, if you want to create a job for the `app_install` scenario, you can create a file named `app_install.json` in the `nomad/var_files` directory.

### Vars file syntax

A simple Example:

```json
{
  "scenario_name": "app_install",
  "behaviours": [
    "large"
  ]
}
```

The following variables are available:

- `scenario_name`: The name of the scenario you want to run. (**required**)
- `behaviours`: A list of behaviours to apply to the scenario. (_optional_, defaults to `[""]`)
- `connection_string`: The connection string to the Holochain conductor. (_optional_, defaults to `ws://localhost:8888`)
- `run_id`: The ID of the run to distinguish it from other runs. (_optional_, defaults to `null`)
- `agents_per_node`: The number of agents per node. (_optional_, defaults to `1`)
- `min_agents`: The minimum number of agents to run the scenario with. (_optional_, defaults to `2`)
- `duration`: The duration of the scenario in seconds. (_optional_, defaults to `300`)
- `reporter`: The reporter type to use. (_optional_, defaults to `influx-file`)

## Generate Nomad Jobs

Once you have created the vars file, you can generate the Nomad job file by running the following command:

```bash
./nomad/generate_jobs.sh
```

This, will generate the nomad job files in the `nomad/jobs` directory. The job files will be named after the scenario name, with the `.nomad.hcl` extension.

Mind that in order to generate the jobs, you need to have `gomplate` installed. You can download the latest version from the [gomplate releases page](https://github.com/hairyhenderson/gomplate/releases).

## Jobs template

Currently, all the jobs are generated from the same template, which is located in `nomad/run_scenario.tpl.hcl`. This template uses the variables defined in the vars file to generate the Nomad job file.

