### PR TITLE
docs: move conventional commits remark in PR template to one line

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,4 @@
 - [ ] All code changes are reflected in docs, including module-level docs
 
 
-_Note that all commits in a PR must follow
-[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it
-can be merged, as these are used to generate the changelog_
+_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


### PR DESCRIPTION
### Summary

GitHub appears to not respect markdown properly and so was adding linebreaks to this remark.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
