### PR TITLE
fix: Telegraf.conf missing tail plugin

### DIFF
--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -163,3 +163,14 @@
 # Read metrics about system load & uptime
 [[inputs.system]]
   # no configuration
+
+[[inputs.tail]]
+    files = ["$WT_METRICS_DIR/*.influx"]
+    from_beginning = false
+    pipe = false
+    watch_method = "inotify"
+    max_undelivered_lines = 1000
+    character_encoding = "utf-8"
+    data_format = "influx"
+    path_tag = ""
+    filters = []


### PR DESCRIPTION
### Summary

The tail plugin was removed by mistake in a previous cleanup of the conf file, but should be there to report metrics when running scenarios

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Telegraf configuration to enable automatic monitoring and ingestion of new `.influx` metric files in the specified directory, using inotify for efficient file change detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->