### PR TITLE
fix: Generate jobs script failed if called without arguments

### DIFF
--- a/nomad/generate_jobs.sh
+++ b/nomad/generate_jobs.sh
@@ -29,7 +29,7 @@ if [ -z "$GOMPLATE" ]; then
   exit 1
 fi
 
-JOB_NAME="$1"
+JOB_NAME="${1:-}"
 
 # generate all
 if [ -z "$JOB_NAME" ]; then


### PR DESCRIPTION
### Summary

The script failed due to the fact that set -e is set and JOB_NAME was set to $1; instead it must be set to ${1:-}

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script reliability by ensuring a key variable is always defined, preventing potential errors when no argument is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->