### PR TITLE
ci: Wait for Nomad CI jobs to run

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -89,6 +89,7 @@ jobs:
           echo "download-url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
 
       - name: Run Nomad Job
+        id: run-nomad-job
         env:
           NIXPKGS_ALLOW_UNFREE: 1
           NOMAD_ADDR: https://nomad-server-01.holochain.org:4646
@@ -97,6 +98,22 @@ jobs:
           NOMAD_VAR_scenario-url: ${{ steps.get-download-url.outputs.download-url }}
           NOMAD_VAR_run-id: ${{ github.run_id }}
         run: |-
-          nix run --impure --inputs-from . nixpkgs#nomad -- job run nomad/jobs/${{ matrix.job-name || matrix.scenario-name }}.nomad.hcl
+          set -euo pipefail
+          nomad_output=$(nix run --impure --inputs-from . nixpkgs#nomad -- job run nomad/jobs/${{ matrix.job-name || matrix.scenario-name }}.nomad.hcl)
+          echo "$nomad_output"
+          echo "Ran ${{ matrix.job-name || matrix.scenario-name }} with run ID ${{ github.run_id }}" >> "$GITHUB_STEP_SUMMARY"
+          alloc_id=$(echo "$nomad_output" | grep -oP --color=never 'Allocation "\K[0-9a-f]+(?=" created)' | paste -sd ' ' -)
+          if [ -z "$alloc_id" ]; then
+            echo "Failed to extract allocation ID from Nomad job output"
+            exit 1
+          fi
 
-          echo "Ran ${{ matrix.job-name }} with run ID ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+          echo "alloc_id=$alloc_id" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for Nomad Job to finish
+        env:
+          RUN_ID: ${{ github.run_id }}
+          NOMAD_ADDR: https://nomad-server-01.holochain.org:4646
+          NOMAD_CACERT: "${{ github.workspace }}/nomad/server-ca-cert.pem"
+          NOMAD_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
+        run: nix develop --command ./nomad/wait_for_jobs.sh ${{ matrix.job-name || matrix.scenario-name }} ${{ steps.run-nomad-job.outputs.alloc_id }}

--- a/nomad/wait_for_jobs.sh
+++ b/nomad/wait_for_jobs.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Timeout in seconds (30 minutes). Can be overridden via environment.
+TIMEOUT="${TIMEOUT:-1800}"
+
+function check_envset() {
+  local var_name="$1"
+  if [[ -z "${!var_name}" ]]; then
+    echo "Environment variable $var_name is not set." >&2
+    exit 1
+  fi
+}
+
+function check_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Command '$cmd' not found in PATH." >&2
+    exit 1
+  fi
+}
+
+
+function get_status() {
+    local alloc_id="$1"
+    # Fetch JSON and extract ClientStatus; fail fast if the command errors.
+    local client_status
+    if ! client_status="$(nomad alloc status -json "${alloc_id}" | jq -r '.ClientStatus')"; then
+        echo "Failed to retrieve status for allocation ID: $alloc_id" >&2
+        exit 1
+    fi
+    if [[ -z "$client_status" || "$client_status" == "null" ]]; then
+        echo "No job found with allocation ID: $alloc_id" >&2
+        exit 1
+    fi
+    echo "$client_status"
+}
+
+function is_running() {
+    local status="$1"
+    case "$status" in
+      complete|failed|lost|stopped|dead|unknown)
+        return 1 ;;  # not running
+      *)
+        return 0 ;;  # still running (e.g., pending, running)
+    esac
+}
+
+function is_run_success() {
+    local status="$1"
+    [[ "$status" == "complete" ]]
+}
+
+function wait_for_job() {
+    local scenario_name="$1"
+    local alloc_id="$2"
+
+    echo "Waiting for job: $scenario_name ($alloc_id)"
+
+    ELAPSED_SECS=0
+    # Run until timeout or no scenario is still running
+    while true; do
+        status=$(get_status "$alloc_id")
+
+        if is_running "$status"; then
+            echo "Scenario $scenario_name ($alloc_id) is still running (status=$status) (elapsed: $ELAPSED_SECS seconds)."
+            sleep 1
+            ELAPSED_SECS=$((ELAPSED_SECS + 1))
+            if [[ $ELAPSED_SECS -gt $TIMEOUT ]]; then
+                echo "Timeout reached after $TIMEOUT seconds."
+                exit 255
+            fi
+            continue
+        fi
+
+        # Job has completed
+        if is_run_success "$status"; then
+            break
+        fi
+
+        echo "Scenario $scenario_name ($alloc_id) failed (status=$status) after $ELAPSED_SECS seconds."
+        exit 1
+    done
+    echo "Scenario $scenario_name ($alloc_id) completed successfully in $ELAPSED_SECS seconds."
+
+    return 0
+}
+
+
+# verify NOMAD variables are set
+# verify NOMAD variables are set
+check_envset "NOMAD_CACERT"
+check_envset "NOMAD_ADDR"
+check_envset "NOMAD_TOKEN"
+
+# verify required tools are available
+check_command "nomad"
+check_command "jq"
+
+# Scenario name must be passed as an argument; at least one allocation ID must be provided
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <scenario_name> <allocation_id> [more_alloc_ids...]"
+  exit 1
+fi
+
+SCENARIO_NAME="$1"
+
+shift # Remove the first argument (scenario name)
+
+# Process each allocation ID passed as arguments
+while [[ $# -gt 0 ]]; do
+    # Get next allocation ID from arguments
+    alloc_id="$1"
+    wait_for_job "$SCENARIO_NAME" "$alloc_id"
+
+    shift # Remove the processed allocation ID
+done
+
+exit 0


### PR DESCRIPTION
closes #164

### Summary

- Added a step to Nomad ci jobs to wait for nomad jobs to complete

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now captures Nomad job output and allocation IDs, then waits for allocations to finish, making submit-then-wait the default flow and surfacing allocation status in step summaries.

* **Chores**
  * Fails early and reports when no allocation is created, adds a sensible timeout, validates required environment and tools, supports sequential handling of multiple allocations, and emits concise run summaries for clearer outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->