### PR TITLE
feat: Integrate Host Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,45 @@ RUST_LOG=info cargo run -p kitsune_continuous_flow -- --bootstrap-server-url htt
 
 If your bootstrap and signal servers run under a different port, adapt the command accordingly. The scenario creates 2 peer and runs for 20 seconds.
 
+### Import Host Metrics
+
+In order to import Host metrics into InfluxDB, you can use the `telegraf` tool. This is a tool that collects and sends metrics to InfluxDB.
+
+Currently, `telegraf` is configured to collect the following metrics:
+
+- CPU stats
+- Disk stats and usage
+- Kernel Info
+- Memory and Swap stats
+- Network stats
+- Processes
+- System stats
+
+You can run a `telegraf` agent to collect host metrics while running scenarios with 
+
+```sh
+nix develop --command telegraf --config ./telegraf/telegraf.host.conf
+```
+
+or by entering the Nix shell and running
+
+```sh
+start_host_metrics_telegraf
+```
+
+Once you've finished running a scenario, you can start the `telegraf` agent to collect both host and scenario metrics with
+
+```sh
+nix run .#local-telegraf
+```
+
+At this point the metrics will be imported to InfluxDB and you will be able to view the Host metrics in the InfluxDB Host dashboard by run_id.
+
+Running the `telegraf` agent will also clean up the previous metrics, so you are immediately ready to run the next scenario.
+
+> [!Warning]
+> The metrics must be imported after each scenario run and cleanup, since they are associated only to the latest scenario run.
+
 ### Published crates
 
 Framework crates:

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1751562746,
-        "narHash": "sha256-smpugNIkmDeicNz301Ll1bD7nFOty97T79m4GUMUczA=",
+        "lastModified": 1754269165,
+        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "aed2020fd3dc26e1e857d4107a5a67a33ab6c1fd",
+        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -136,16 +136,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1750866060,
-        "narHash": "sha256-H9K+83vNPRRIV8e3HmLEHqdx0w03e8aiEF2NhYLXbD0=",
+        "lastModified": 1752078164,
+        "narHash": "sha256-Jl7l3z3LJ9nB/2yPwTUM5s5eYc1G+40lZ3rK2lpm5O4=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "8061d5b02f8eb03abfb6942b0a502d0d9bd3249f",
+        "rev": "ba3bcf4d0da1b3683f1f715fafa6b469d89721c1",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.5.3",
+        "ref": "holochain-0.5.4",
         "repo": "holochain",
         "type": "github"
       }
@@ -164,11 +164,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1751364451,
-        "narHash": "sha256-1/p8XUQBS9l84TfGDZRVj4li5DcW/XTuEyeGQVKWg7g=",
+        "lastModified": 1752096312,
+        "narHash": "sha256-mP8nfNRBI+2swc3lCXzxLXyD6SAb7JHnAC17R0v6h+Q=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "a3aeb7c87e1dba3569a8b36690f66e6a74b8c145",
+        "rev": "5e00d7be074f3b4dcfd5340a14c7046ce000fccf",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
         "type": "github"
       },
       "original": {
@@ -310,11 +310,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1751741127,
-        "narHash": "sha256-t75Shs76NgxjZSgvvZZ9qOmz5zuBE8buUaYD28BMTxg=",
+        "lastModified": 1754937576,
+        "narHash": "sha256-3sWA5WJybUE16kIMZ3+uxcxKZY/JRR4DFBqLdSLBo7w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29e290002bfff26af1db6f64d070698019460302",
+        "rev": "ddae11e58c0c345bf66efbddbf2192ed0e58f896",
         "type": "github"
       },
       "original": {
@@ -348,7 +348,8 @@
         "holonix": "holonix",
         "kitsune2": "kitsune2_2",
         "nixpkgs": "nixpkgs_3",
-        "rust-overlay": "rust-overlay_3"
+        "rust-overlay": "rust-overlay_3",
+        "unstable": "unstable"
       }
     },
     "rust-overlay": {
@@ -400,16 +401,32 @@
         ]
       },
       "locked": {
-        "lastModified": 1751856221,
-        "narHash": "sha256-/QE1eV0ckFvgRMcKjZqgdJDoXFNwSMepwRoBjaw2MCk=",
+        "lastModified": 1755052812,
+        "narHash": "sha256-Tjw2YP7Hz8+ibE8wJ+Ps65vh1lzAe5ozmoo9sdQ7rGg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "34cae4b56929c5b340e1c5b10d9a98a425b2a51e",
+        "rev": "433023cba5f4fa66b8b0fdbb8f91d420c9cc2527",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "unstable": {
+      "locked": {
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.05";
+    unstable.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     holonix = {
@@ -23,11 +24,12 @@
     };
   };
 
-  outputs = inputs@{ flake-parts, crane, rust-overlay, nixpkgs, ... }: flake-parts.lib.mkFlake { inherit inputs; } ({ flake-parts-lib, ... }: {
+  outputs = inputs@{ flake-parts, crane, rust-overlay, nixpkgs, unstable, ... }: flake-parts.lib.mkFlake { inherit inputs; } ({ flake-parts-lib, ... }: {
     systems = builtins.attrNames inputs.holonix.devShells;
     perSystem = { inputs', pkgs, system, config, ... }:
       let
         unfreePkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+        unstablePkgs = import unstable { inherit system; };
         rustMod = flake-parts-lib.importApply ./nix/modules/rust.nix { inherit crane rust-overlay nixpkgs; };
 
         # Enable unstable and non-default features that Wind Tunnel tests.
@@ -73,7 +75,7 @@
                 pkgs.influxdb2-cli
                 pkgs.influxdb2-server
                 # TODO https://docs.influxdata.com/telegraf/v1/install/#ntp
-                pkgs.telegraf
+                unstablePkgs.telegraf
                 pkgs.yq
                 pkgs.httpie
                 unfreePkgs.nomad
@@ -111,10 +113,81 @@
         packages = {
           default = config.workspace.workspace;
           inherit (config.workspace) workspace;
+          local-telegraf = pkgs.writeShellApplication {
+            name = "local-telegraf";
+            runtimeInputs = [
+              pkgs.gnused
+              pkgs.jq
+              pkgs.yq
+              unstablePkgs.telegraf
+            ];
+            text = ''
+              set -euo pipefail
+
+              # shellcheck disable=SC1091
+              source ./scripts/influx.sh
+              
+              use_influx
+              
+              WT_METRICS_DIR="$(pwd)/telegraf/metrics"
+              export WT_METRICS_DIR
+
+              # Get run id from the latest run summary or set it to ""
+              if [ -f run_summary.jsonl ]; then
+                RUN_ID=$(jq --slurp --raw-output 'sort_by(.started_at|tonumber) | last | .run_id' < run_summary.jsonl)
+              else
+                RUN_ID=""
+              fi
+
+              # get tempfile for telegraf config
+              TELEGRAF_CONFIG=$(mktemp --suffix ".conf")
+              cp ./telegraf/telegraf.local.conf "$TELEGRAF_CONFIG"
+
+              sed --in-place "s/run_id = \"\"/run_id = \"$RUN_ID\"/" "$TELEGRAF_CONFIG"
+
+              echo "Running telegraf for run ID: $RUN_ID"
+              telegraf --config "$TELEGRAF_CONFIG" --once > >(tee logs/telegraf-stdout.log) 2> >(tee logs/telegraf-stderr.log >&2)
+
+              rm ./telegraf/metrics/*.influx
+            '';
+          };
           ci-telegraf = pkgs.writeShellApplication {
             name = "ci-telegraf";
-            runtimeInputs = [ pkgs.telegraf ];
-            text = "telegraf --config telegraf/runner-telegraf.conf --once > >(tee logs/telegraf-stdout.log) 2> >(tee logs/telegraf-stderr.log >&2)";
+            runtimeInputs = [
+              pkgs.gnused
+              pkgs.jq
+              pkgs.yq
+              unstablePkgs.telegraf
+            ];
+            text = ''
+              set -euo pipefail
+
+              # shellcheck disable=SC1091
+              source ./scripts/influx.sh
+              
+              use_influx
+
+              WT_METRICS_DIR="$(pwd)/telegraf/metrics"
+              export WT_METRICS_DIR
+
+              # Get run id from the latest run summary or set it to ""
+              if [ -f run_summary.jsonl ]; then
+                RUN_ID=$(jq --slurp --raw-output 'sort_by(.started_at|tonumber) | last | .run_id' < run_summary.jsonl)
+              else
+                RUN_ID=""
+              fi
+              
+              # get tempfile for telegraf config
+              TELEGRAF_CONFIG=$(mktemp --suffix ".conf")
+              cp ./telegraf/telegraf.runner.conf "$TELEGRAF_CONFIG"
+
+              sed --in-place "s/run_id = \"\"/run_id = \"$RUN_ID\"/" "$TELEGRAF_CONFIG"
+
+              echo "Running telegraf for run ID: $RUN_ID"
+              telegraf --config "$TELEGRAF_CONFIG" --once > >(tee logs/telegraf-stdout.log) 2> >(tee logs/telegraf-stderr.log >&2)
+
+              rm ./telegraf/metrics/*.influx
+            '';
           };
         };
 

--- a/influx/templates/dashboards/host.json
+++ b/influx/templates/dashboards/host.json
@@ -20,7 +20,7 @@
           "name": "System Uptime",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"system\")\n  |> filter(fn: (r) => r._field == \"uptime\")\n  |> last()\n  |> map(fn: (r) => ({ _value: float(v: r._value) / 86400.00 }))"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"system\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"uptime\")\n  |> last()\n  |> map(fn: (r) => ({ _value: float(v: r._value) / 86400.00 }))"
             }
           ],
           "staticLegend": {},
@@ -40,7 +40,7 @@
           "name": "Disk Usage",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"disk\")\n  |> filter(fn: (r) => r._field == \"used_percent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"disk\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"used_percent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
             }
           ],
           "staticLegend": {},
@@ -59,7 +59,7 @@
           "name": "Disk IO",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"diskio\")\n  |> filter(fn: (r) => r._field == \"read_bytes\" or r._field == \"write_bytes\")\n  |> derivative(unit: v.windowPeriod, nonNegative: false)"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"diskio\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"read_bytes\" or r._field == \"write_bytes\")\n  |> derivative(unit: v.windowPeriod, nonNegative: false)"
             }
           ],
           "staticLegend": {},
@@ -74,7 +74,7 @@
           "name": "nCPUs",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"system\")\n  |> filter(fn: (r) => r._field == \"n_cpus\")\n  |> last()"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"system\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"n_cpus\")\n  |> last()"
             }
           ],
           "staticLegend": {},
@@ -95,7 +95,7 @@
           "name": "CPU Usage",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"cpu\")\n  |> filter(fn: (r) => r._field == \"usage_user\" or r._field == \"usage_system\" or r._field == \"usage_idle\")\n  |> filter(fn: (r) => r.cpu == \"cpu-total\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"cpu\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"usage_user\" or r._field == \"usage_system\" or r._field == \"usage_idle\")\n  |> filter(fn: (r) => r.cpu == \"cpu-total\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
             }
           ],
           "staticLegend": {},
@@ -115,7 +115,7 @@
           "name": "Network",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"net\")\n  |> filter(fn: (r) => r._field == \"bytes_recv\" or r._field == \"bytes_sent\")\n  |> derivative(unit: v.windowPeriod, nonNegative: false)"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"net\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"bytes_recv\" or r._field == \"bytes_sent\")\n  |> derivative(unit: v.windowPeriod, nonNegative: false)"
             }
           ],
           "staticLegend": {},
@@ -133,7 +133,7 @@
           "name": "System Load",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"system\")\n  |> filter(fn: (r) => r._field == \"load1\")\n  |> last()"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"system\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"load1\")\n  |> last()"
             }
           ],
           "staticLegend": {},
@@ -153,7 +153,7 @@
           "name": "System Load",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"system\")\n  |> filter(fn: (r) => r._field == \"load1\" or r._field == \"load5\" or r._field == \"load15\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"system\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"load1\" or r._field == \"load5\" or r._field == \"load15\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
             }
           ],
           "staticLegend": {},
@@ -173,7 +173,7 @@
           "name": "Processes",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"processes\")\n  |> filter(fn: (r) => r._field == \"running\" or r._field == \"blocked\" or r._field == \"idle\" or r._field == \"unknown\")\n  |> aggregateWindow(every: v.windowPeriod, fn: max)"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"processes\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"running\" or r._field == \"blocked\" or r._field == \"idle\" or r._field == \"unknown\")\n  |> aggregateWindow(every: v.windowPeriod, fn: max)"
             }
           ],
           "staticLegend": {},
@@ -189,7 +189,7 @@
           "name": "Total Memory",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"mem\")  \n  |> filter(fn: (r) => r._field == \"total\")\n  |> last()  \n  |> map(fn: (r) => ({r with _value: float(v: r._value) / 1024.0 / 1024.0 / 1024.0}))"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"mem\")  \n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"total\")\n  |> last()  \n  |> map(fn: (r) => ({r with _value: float(v: r._value) / 1024.0 / 1024.0 / 1024.0}))"
             }
           ],
           "staticLegend": {},
@@ -228,7 +228,7 @@
           "name": "Memory Usage",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"mem\")\n  |> filter(fn: (r) => r._field == \"used_percent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"mem\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"used_percent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
             }
           ],
           "staticLegend": {},
@@ -249,7 +249,7 @@
           "name": "Swap",
           "queries": [
             {
-              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"swap\")\n  |> filter(fn: (r) => r._field == \"total\" or r._field == \"used\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+              "query": "from(bucket: \"windtunnel\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"swap\")\n  |> filter(fn: (r) => r[\"run_id\"] == v.RunId)\n  |> filter(fn: (r) => r._field == \"total\" or r._field == \"used\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
             }
           ],
           "staticLegend": {},

--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -160,7 +160,7 @@ job "{{ (ds "vars").scenario_name }}" {
           }
 
           env {
-            TELEGRAF_CONFIG_PATH = "${NOMAD_TASK_DIR}/runner-telegraf.conf"
+            TELEGRAF_CONFIG_PATH = "${NOMAD_TASK_DIR}/telegraf.runner.conf"
             WT_METRICS_DIR       = "${NOMAD_ALLOC_DIR}/data/telegraf/metrics"
           }
 
@@ -175,7 +175,7 @@ job "{{ (ds "vars").scenario_name }}" {
           driver = "raw_exec"
 
           artifact {
-            source = "https://raw.githubusercontent.com/holochain/wind-tunnel/refs/heads/main/telegraf/runner-telegraf.conf"
+            source = "https://raw.githubusercontent.com/holochain/wind-tunnel/refs/heads/main/telegraf/telegraf.runner.conf"
           }
 
           config {

--- a/scripts/telegraf.sh
+++ b/scripts/telegraf.sh
@@ -9,5 +9,9 @@ start_telegraf() {
         return 1
     fi
 
-    telegraf --config "$(pwd)/telegraf/telegraf.conf"
+    telegraf --config "$(pwd)/telegraf/telegraf.local.conf"
+}
+
+start_host_metrics_telegraf() {
+    telegraf --config "$(pwd)/telegraf/telegraf.host.conf"
 }

--- a/telegraf/telegraf.host.conf
+++ b/telegraf/telegraf.host.conf
@@ -1,20 +1,3 @@
-# Telegraf Configuration
-#
-# Telegraf is entirely plugin driven. All metrics are gathered from the
-# declared inputs, and sent to the declared outputs.
-#
-# Plugins must be declared in here to be active.
-# To deactivate a plugin, comment out the name and any variables.
-#
-# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
-# file would generate.
-#
-# Environment variables can be used anywhere in this config file, simply surround
-# them with ${}. For strings the variable must be within quotes (ie, "${STR_VAR}"),
-# for numbers and booleans they should be plain (ie, ${INT_VAR}, ${BOOL_VAR})
-
-
-# Configuration for telegraf agent
 [agent]
   ## Default data collection interval for all inputs
   interval = "10s"
@@ -30,7 +13,7 @@
   ## Maximum number of unwritten metrics per output.  Increasing this value
   ## allows for longer periods of output downtime without dropping metrics at the
   ## cost of higher maximum memory usage.
-  metric_buffer_limit = 1000000
+  metric_buffer_limit = 10000
 
   ## Collection jitter is used to jitter the collection by a random amount.
   ## Each plugin will sleep for a random time within jitter before collecting.
@@ -45,7 +28,7 @@
 
   ## Default flushing interval for all outputs. Maximum flush_interval will be
   ## flush_interval + flush_jitter
-  flush_interval = "60s"
+  flush_interval = "10s"
   ## Jitter the flush interval by a random amount. This is primarily to avoid
   ## large write spikes for users running a large number of telegraf instances.
   ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
@@ -66,6 +49,7 @@
 
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""
+
   ## If set to true, do no set the "host" tag in the telegraf agent.
   omit_hostname = false
 
@@ -73,24 +57,9 @@
 #                            OUTPUT PLUGINS                                   #
 ###############################################################################
 
-
-# Configuration for sending metrics to InfluxDB 2.0
-[[outputs.influxdb_v2]]
-  ## The URLs of the InfluxDB cluster nodes.
-  ##
-  ## Multiple URLs can be specified for a single cluster, only ONE of the
-  ## urls will be written to each interval.
-  ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
-  urls = ["https://ifdb.holochain.org"]
-
-  ## Token for authentication.
-  token = "${INFLUX_TOKEN}"
-
-  ## Organization is the name of the organization you wish to write to.
-  organization = "holo"
-
-  ## Destination bucket to write into.
-  bucket = "windtunnel"
+[[outputs.file]]
+  files = ["./telegraf/metrics/host.influx"]
+  data_format = "influx"
 
 ###############################################################################
 #                            INPUT PLUGINS                                    #
@@ -124,38 +93,8 @@
   ## By default, telegraf will gather stats for all devices including
   ## disk partitions.
 
-[[inputs.file]]
-  ## Files to parse each interval.  Accept standard unix glob matching rules,
-  ## as well as ** to match recursive files and directories.
-  files = ["${WT_METRICS_DIR}/*.influx"]
-
-  ## Character encoding to use when interpreting the file contents.  Invalid
-  ## characters are replaced using the unicode replacement character.  When set
-  ## to the empty string the data is not decoded to text.
-  ##   ex: character_encoding = "utf-8"
-  ##       character_encoding = "utf-16le"
-  ##       character_encoding = "utf-16be"
-  ##       character_encoding = ""
-  character_encoding = "utf-8"
-
-  ## Data format to consume.
-  ## Each data format has its own unique set of configuration options, read
-  ## more about them here:
-  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-  data_format = "influx"
-
-
-  ## Name a tag containing the name of the file the data was parsed from.  Leave empty
-  ## to disable. Cautious when file name variation is high, this can increase the cardinality
-  ## significantly. Read more about cardinality here:
-  ## https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series-cardinality
-  # file_tag = ""
-
 [[inputs.kernel]]
-  ## Additional gather options
-  ## Possible options include:
-  ## * ksm - kernel same-page merging
-  # collect = []
+  # no configuration
 
 # Read metrics about memory usage
 [[inputs.mem]]

--- a/telegraf/telegraf.local.conf
+++ b/telegraf/telegraf.local.conf
@@ -1,0 +1,82 @@
+# Telegraf Configuration
+#
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared inputs, and sent to the declared outputs.
+#
+# Plugins must be declared in here to be active.
+# To deactivate a plugin, comment out the name and any variables.
+#
+# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+# file would generate.
+#
+# Environment variables can be used anywhere in this config file, simply surround
+# them with ${}. For strings the variable must be within quotes (ie, "${STR_VAR}"),
+# for numbers and booleans they should be plain (ie, ${INT_VAR}, ${BOOL_VAR})
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+
+
+# Configuration for sending metrics to InfluxDB 2.0
+[[outputs.influxdb_v2]]
+  ## The URLs of the InfluxDB cluster nodes.
+  ##
+  ## Multiple URLs can be specified for a single cluster, only ONE of the
+  ## urls will be written to each interval.
+  ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
+  urls = ["http://127.0.0.1:8087"]
+
+  ## Token for authentication.
+  token = "${INFLUX_TOKEN}"
+
+  ## Organization is the name of the organization you wish to write to.
+  organization = "holo"
+
+  ## Destination bucket to write into.
+  bucket = "windtunnel"
+
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+
+[[inputs.file]]
+  ## Files to parse each interval.  Accept standard unix glob matching rules,
+  ## as well as ** to match recursive files and directories.
+  files = ["${WT_METRICS_DIR}/*.influx"]
+
+  ## Character encoding to use when interpreting the file contents.  Invalid
+  ## characters are replaced using the unicode replacement character.  When set
+  ## to the empty string the data is not decoded to text.
+  ##   ex: character_encoding = "utf-8"
+  ##       character_encoding = "utf-16le"
+  ##       character_encoding = "utf-16be"
+  ##       character_encoding = ""
+  character_encoding = "utf-8"
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"
+
+
+  ## Name a tag containing the name of the file the data was parsed from.  Leave empty
+  ## to disable. Cautious when file name variation is high, this can increase the cardinality
+  ## significantly. Read more about cardinality here:
+  ## https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series-cardinality
+  # file_tag = ""
+
+## Set default fields and tags on your metric(s) when they are nil or empty
+[[processors.defaults]]
+  ## Ensures a set of fields or tags always exists on your metric(s) with their
+  ## respective default value.
+  ## For any given field/tag pair (key = default), if it's not set, a field/tag
+  ## is set on the metric with the specified default.
+  ##
+  ## A tag is considered not set if it is nil on the incoming metric;
+  ## or it is not nil but it is empty string or a string of one or
+  ## more spaces.
+  ## <target-tag> = <value>
+  [processors.defaults.tags]
+    run_id = ""

--- a/telegraf/telegraf.runner.conf
+++ b/telegraf/telegraf.runner.conf
@@ -1,0 +1,82 @@
+# Telegraf Configuration
+#
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared inputs, and sent to the declared outputs.
+#
+# Plugins must be declared in here to be active.
+# To deactivate a plugin, comment out the name and any variables.
+#
+# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+# file would generate.
+#
+# Environment variables can be used anywhere in this config file, simply surround
+# them with ${}. For strings the variable must be within quotes (ie, "${STR_VAR}"),
+# for numbers and booleans they should be plain (ie, ${INT_VAR}, ${BOOL_VAR})
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+
+
+# Configuration for sending metrics to InfluxDB 2.0
+[[outputs.influxdb_v2]]
+  ## The URLs of the InfluxDB cluster nodes.
+  ##
+  ## Multiple URLs can be specified for a single cluster, only ONE of the
+  ## urls will be written to each interval.
+  ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
+  urls = ["https://ifdb.holochain.org"]
+
+  ## Token for authentication.
+  token = "${INFLUX_TOKEN}"
+
+  ## Organization is the name of the organization you wish to write to.
+  organization = "holo"
+
+  ## Destination bucket to write into.
+  bucket = "windtunnel"
+
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+
+[[inputs.file]]
+  ## Files to parse each interval.  Accept standard unix glob matching rules,
+  ## as well as ** to match recursive files and directories.
+  files = ["${WT_METRICS_DIR}/*.influx"]
+
+  ## Character encoding to use when interpreting the file contents.  Invalid
+  ## characters are replaced using the unicode replacement character.  When set
+  ## to the empty string the data is not decoded to text.
+  ##   ex: character_encoding = "utf-8"
+  ##       character_encoding = "utf-16le"
+  ##       character_encoding = "utf-16be"
+  ##       character_encoding = ""
+  character_encoding = "utf-8"
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"
+
+
+  ## Name a tag containing the name of the file the data was parsed from.  Leave empty
+  ## to disable. Cautious when file name variation is high, this can increase the cardinality
+  ## significantly. Read more about cardinality here:
+  ## https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series-cardinality
+  # file_tag = ""
+
+## Set default fields and tags on your metric(s) when they are nil or empty
+[[processors.defaults]]
+  ## Ensures a set of fields or tags always exists on your metric(s) with their
+  ## respective default value.
+  ## For any given field/tag pair (key = default), if it's not set, a field/tag
+  ## is set on the metric with the specified default.
+  ##
+  ## A tag is considered not set if it is nil on the incoming metric;
+  ## or it is not nil but it is empty string or a string of one or
+  ## more spaces.
+  ## <target-tag> = <value>
+  [processors.defaults.tags]
+    run_id = ""


### PR DESCRIPTION
### Summary

Added telegraf configurations and scripts to import Host and scenario metrics by the last run_id. Added a telegraf agent configuration to write Host metrics to file

closes #208

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - New local and CI Telegraf runners and a user command to import host metrics per run; packaged for easy local invocation.

- **Improvements**
  - Dashboards now filter metrics by Run ID for per-run isolation.
  - Runners use per-run dynamic configuration, capture per-run logs, clean up metrics between runs, and flush metrics more frequently for faster visibility.

- **Documentation**
  - Added an "Import Host Metrics" guide (appears duplicated in README).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->