### PR TITLE
Fix auto update lockfiles ci

### DIFF
--- a/.github/workflows/cargo_update.yaml
+++ b/.github/workflows/cargo_update.yaml
@@ -28,5 +28,4 @@ jobs:
           title: "chore: update Cargo.lock file"
           body: "This PR updates the Cargo.lock file."
           branch: "update-cargo-lock"
-          branch-suffix: "short-commit-hash"
           base: "main"

--- a/.github/workflows/flake_update.yaml
+++ b/.github/workflows/flake_update.yaml
@@ -28,5 +28,4 @@ jobs:
           title: "chore: update flake.lock file"
           body: "This PR updates the flake.lock file."
           branch: "update-flake-lock"
-          branch-suffix: "short-commit-hash"
           base: "main"


### PR DESCRIPTION
### Summary

By having the commit hash as part of the branch name, a new PR is created every time these CI jobs are run.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized branch names for automated dependency update pull requests by removing dynamic suffixes. PR branches will now be exactly “update-cargo-lock” and “update-flake-lock,” improving consistency and predictability.
  - No impact to application behavior; streamlines repository hygiene, makes automated PRs easier to track, search, and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->