### PR TITLE
fix(nomad): Change nomad upload metrics script to use lp-tool and influx write instead of telegraf

### DIFF
--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -190,10 +190,11 @@ job "{{ (ds "vars").scenario_name }}" {
           }
 
           env {
-            TELEGRAF_CONFIG_PATH = "${NOMAD_TASK_DIR}/telegraf.runner.conf"
             WT_METRICS_DIR       = "${NOMAD_ALLOC_DIR}/data/telegraf/metrics"
             RUN_ID               = "${var.run-id != null ? var.run-id : ""}"
             RUN_SUMMARY_PATH     = "${NOMAD_ALLOC_DIR}/run_summary.jsonl"
+            INFLUX_HOST          = "https://ifdb.holochain.org"
+            INFLUX_BUCKET        = "windtunnel"
           }
 
           template {
@@ -208,10 +209,6 @@ job "{{ (ds "vars").scenario_name }}" {
 
           artifact {
             source = "https://raw.githubusercontent.com/holochain/wind-tunnel/refs/heads/main/nomad/upload_metrics.sh"
-          }
-
-          artifact {
-            source = "https://raw.githubusercontent.com/holochain/wind-tunnel/refs/heads/main/telegraf/telegraf.runner.conf"
           }
 
           config {

--- a/nomad/upload_metrics.sh
+++ b/nomad/upload_metrics.sh
@@ -15,15 +15,15 @@ function check_envset() {
 
 check_envset "WT_METRICS_DIR"
 check_envset "INFLUX_TOKEN"
-check_envset "TELEGRAF_CONFIG_PATH"
+check_envset "INFLUX_HOST"
+check_envset "NOMAD_ALLOC_DIR"
+
+influx_bucket="${INFLUX_BUCKET:-windtunnel}"
 
 # read RUN_ID if not set in the environment
-if [ -z "$RUN_ID" ]; then
+if [ "${RUN_ID:+x}" == "x" ]; then
     # if is set RUN_SUMMARY_PATH
-    summary_path="run_summary.jsonl"
-    if [ ! -z "$RUN_SUMMARY_PATH" ]; then
-        summary_path="$RUN_SUMMARY_PATH"
-    fi
+    summary_path=${RUN_SUMMARY_PATH:-"run_summary.jsonl"}
 
     if [ -f "$summary_path" ]; then
         RUN_ID=$(jq --slurp --raw-output 'sort_by(.started_at|tonumber) | last | .run_id' < "$summary_path")
@@ -32,8 +32,24 @@ if [ -z "$RUN_ID" ]; then
         RUN_ID=""
     fi
     export RUN_ID
+    echo "RUN_ID: '$RUN_ID'"
 fi
 
-echo "RUN_ID: '$RUN_ID'"
-
-telegraf --once
+# for each metric file, import to influx
+for metric_file in "$WT_METRICS_DIR"/*.influx; do
+    echo "Importing $metric_file"
+    out_file="$NOMAD_ALLOC_DIR/$(basename "$metric_file")"
+    # Tag metrics with RUN_ID, if set
+    if [[ "${RUN_ID:+x}" == "x" ]]; then
+        lp-tool -input "$metric_file" -output "$out_file" -tag run_id="$RUN_ID"
+    else
+        cp "$metric_file" "$out_file"
+    fi
+    # import metrics to influx
+    influx write \
+        --host "$INFLUX_HOST" \
+        --bucket "$influx_bucket" \
+        --org "holo" \
+        --file "$out_file"
+    echo "Finished importing $metric_file"
+done


### PR DESCRIPTION
### Summary

closes #259

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Direct InfluxDB-based metrics upload with per-file progress logs.
  * New environment variables: INFLUX_HOST and INFLUX_BUCKET.
  * Optional run ID tagging with visible RUN_ID output.

* Bug Fixes
  * More reliable RUN_ID detection from run summaries with clear error messaging when unavailable.
  * Safer temp-file handling and cleanup during metric tagging.

* Chores
  * Removed Telegraf dependency and related configuration, simplifying setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->