### PR TITLE
ci: parallelise the running of nomad jobs

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -75,6 +75,7 @@ jobs:
               else
                   echo -n "."
               fi
+              sleep 5
           done
           echo "done"
 
@@ -103,17 +104,46 @@ jobs:
           nomad_output=$(nix run --impure --inputs-from . nixpkgs#nomad -- job run nomad/jobs/${{ matrix.job-name || matrix.scenario-name }}.nomad.hcl)
           echo "$nomad_output"
           echo "Ran ${{ matrix.job-name || matrix.scenario-name }} with run ID ${RUN_ID}" >> "$GITHUB_STEP_SUMMARY"
-          alloc_id=$(echo "$nomad_output" | grep -oP --color=never 'Allocation "\K[0-9a-f]+(?=" created)' | paste -sd ' ' -)
-          if [ -z "$alloc_id" ]; then
-            echo "Failed to extract allocation ID from Nomad job output"
+          alloc_ids=$(echo "$nomad_output" | grep -oP --color=never 'Allocation "\K[0-9a-f]+(?=" created)' | paste -sd ' ' -)
+          if [ -z "$alloc_ids" ]; then
+            echo "Failed to extract allocation IDs from Nomad job output"
             exit 1
           fi
 
-          echo "alloc_id=$alloc_id" >> "$GITHUB_OUTPUT"
+          echo "alloc_ids=$alloc_ids" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for Nomad Job to finish
+      - name: Save alloc_ids to file
+        run: |
+          for alloc_id in ${{ steps.run-nomad-job.outputs.alloc_ids }}; do
+            echo "${{ matrix.job-name || matrix.scenario-name }},${alloc_id}" >> alloc_ids.csv
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: alloc_ids_${{ matrix.job-name || matrix.scenario-name }}
+          path: alloc_ids.csv
+
+  wait-for-all-jobs:
+    name: Wait for all jobs to finish
+    runs-on: [self-hosted, wind-tunnel]
+    needs: run-scenarios
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: ./alloc_ids
+
+      - name: Wait for all jobs
         env:
           NOMAD_ADDR: https://nomad-server-01.holochain.org:4646
           NOMAD_CACERT: "${{ github.workspace }}/nomad/server-ca-cert.pem"
           NOMAD_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
-        run: nix develop --command ./nomad/wait_for_jobs.sh ${{ matrix.job-name || matrix.scenario-name }} ${{ steps.run-nomad-job.outputs.alloc_id }}
+        run: |-
+          cat ./alloc_ids/*/alloc_ids.csv > all_alloc_ids.csv
+          while IFS= read -r line; do
+            scenario_name=$(echo "$line" | cut -d',' -f1)
+            alloc_id=$(echo "$line" | cut -d',' -f2)
+            echo "Waiting for $scenario_name with allocation ID $alloc_id"
+            nix develop --command ./nomad/wait_for_jobs.sh $scenario_name $alloc_id
+          done < all_alloc_ids.csv

--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -77,6 +77,12 @@ job "{{ (ds "vars").scenario_name }}" {
     labels   = ["${var.scenario-name}-${group.key}-${group.value}"]
 
     content {
+      restart {
+        interval         = "30m"
+        attempts         = 5
+        delay            = "120s"
+      }
+
       task "start_holochain" {
         lifecycle {
           hook    = "prestart"
@@ -95,6 +101,7 @@ job "{{ (ds "vars").scenario_name }}" {
         }
 
         resources {
+          cores = 2
           memory = 2048
         }
       }


### PR DESCRIPTION
### Summary

closes #268

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waits on multiple Nomad allocations across all scenarios with a dedicated aggregate wait step.
  * Per-run allocation IDs are saved as artifacts and aggregated for cross-run monitoring.
  * Added a small pause when waiting for free nodes to improve resource availability handling.

* **Bug Fixes / Reliability**
  * Enforced presence of allocation IDs before proceeding, improving error reporting.

* **Chores**
  * Added automatic restart policy and increased CPU for the Holochain task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->