### PR TITLE
chore(nomad): Cleanup Nomad job spec variables

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -98,8 +98,8 @@ jobs:
           NOMAD_ADDR: https://nomad-server-01.holochain.org:4646
           NOMAD_CACERT: "${{ github.workspace }}/nomad/server-ca-cert.pem"
           NOMAD_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
-          NOMAD_VAR_scenario-url: ${{ steps.get-download-url.outputs.download-url }}
-          NOMAD_VAR_run-id: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
+          NOMAD_VAR_scenario_url: ${{ steps.get-download-url.outputs.download-url }}
+          NOMAD_VAR_run_id: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
           RUN_ID: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
         run: |-
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -562,6 +562,12 @@ accessible.
 > Unlike when running locally in the section above, we cannot just pass a path because the path needs to be
 > accessible to the client and Nomad doesn't have native support for uploading artefacts.
 
+At this point you have to generate the Nomad job for the scenario you want to run. This is done with:
+
+```bash
+./nomad/generate_jobs.sh app_install_minimal
+```
+
 Now that the bundle is publicly available you can run the scenario with the following:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -477,24 +477,24 @@ Replace `app_install` with the name of the scenario that you want to run.
 Once the scenario is built you can run the Nomad job with:
 
 ```bash
-nomad job run -address=http://localhost:4646 -var scenario-url=result/bin/app_install -var reporter=in-memory nomad/jobs/app_install_minimal.nomad.hcl
+nomad job run -address=http://localhost:4646 -var scenario_url=result/bin/app_install -var reporter=in-memory nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
 All the jobs are in the `nomad/jobs` directory, so you can replace `app_install_minimal` with the name of the job you want to run.
 
 - `-address` sets Nomad to talk to the locally running instance and not the dedicated Wind Tunnel cluster one.
-- `-var scenario-url=...` provides the path to the scenario binary that you built in the previous step.
+- `-var scenario_url=...` provides the path to the scenario binary that you built in the previous step.
 - `-var reporter=in-memory` sets the reporter type to print to `stdout` instead of writing an InfluxDB metrics file.
 
 > [!Warning]
-> When running locally as in this guide, the `reporter` must be set to `in-memory` and the `scenario-url` must be a
+> When running locally as in this guide, the `reporter` must be set to `in-memory` and the `scenario_url` must be a
 > local path due to the way Nomad handles downloading. To get around this limitation you must disable file system
 > isolation, see <https://developer.hashicorp.com/nomad/docs/configuration/client#disable_filesystem_isolation>.
 
 You can also override existing and omitted variables with the `-var` flag. For example, to set the duration (in seconds) use:
 
 ```bash
-nomad job run -address=http://localhost:4646 -var scenario-url=result/bin/app_install -var reporter=in-memory -var duration=300 nomad/jobs/app_install_minimal.nomad.hcl
+nomad job run -address=http://localhost:4646 -var scenario_url=result/bin/app_install -var reporter=in-memory -var duration=300 nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
 > [!Note]
@@ -565,17 +565,17 @@ accessible.
 Now that the bundle is publicly available you can run the scenario with the following:
 
 ```bash
-nomad job run -var-file=nomad/var_files/app_install_minimal.vars -var scenario-url=http://{some-url} nomad/run_scenario.nomad.hcl
+nomad job run -var scenario_url=http://{some-url} nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
 - `-var-file` should point to the var file, in `nomad/var_files`, of the scenario you want to run.
-- `-var scenario-url=...` provides the URL to the scenario binary that you uploaded in the previous step.
+- `-var scenario_url=...` provides the URL to the scenario binary that you uploaded in the previous step.
 
 You can also override existing and omitted variables with the `-var` flag. For example, to set the duration
 (in seconds) or to set the reporter to print to `stdout`.
 
 ```bash
-nomad job run -var-file=nomad/var_files/app_install_minimal.vars -var scenario-url=http://{some-url} -var reporter=in-memory -var duration=300 nomad/run_scenario.nomad.hcl
+nomad job run -var scenario_url=http://{some-url} -var reporter=in-memory -var duration=300 nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
 > [!Note]

--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -134,7 +134,7 @@ job "{{ (ds "vars").scenario_name }}" {
           RUST_LOG          = "info"
           HOME              = "${NOMAD_TASK_DIR}"
           WT_METRICS_DIR    = "${NOMAD_ALLOC_DIR}/data/telegraf/metrics"
-          MIN_AGENTS        = "{{ index (ds "vars") "min_agents" | default 2 }}"
+          MIN_AGENTS        = "{{ math.Mul (index (ds "vars") "agents_per_node" | default 1) 2 }}"
           RUN_SUMMARY_PATH  = "${NOMAD_ALLOC_DIR}/run_summary.jsonl"
         }
 

--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -134,7 +134,7 @@ job "{{ (ds "vars").scenario_name }}" {
           RUST_LOG          = "info"
           HOME              = "${NOMAD_TASK_DIR}"
           WT_METRICS_DIR    = "${NOMAD_ALLOC_DIR}/data/telegraf/metrics"
-          MIN_AGENTS        = "{{ math.Mul (index (ds "vars") "agents_per_node" | default 1) 2 }}"
+          MIN_AGENTS        = "{{ mul (index (ds "vars") "agents_per_node" | default 1) (len (index (ds "vars") "behaviours" | default (coll.Slice "") )) }}"
           RUN_SUMMARY_PATH  = "${NOMAD_ALLOC_DIR}/run_summary.jsonl"
         }
 

--- a/nomad/vars/validation_receipts.json
+++ b/nomad/vars/validation_receipts.json
@@ -1,9 +1,5 @@
 {
   "scenario_name": "validation_receipts",
-  "behaviours": [
-    "",
-    ""
-  ],
-  "agents_per_node": 5,
-  "min_agents": 10
+  "behaviours": ["", ""],
+  "agents_per_node": 5
 }

--- a/nomad/vars/validation_receipts.json
+++ b/nomad/vars/validation_receipts.json
@@ -1,5 +1,8 @@
 {
   "scenario_name": "validation_receipts",
-  "behaviours": ["", ""],
+  "behaviours": [
+    "",
+    ""
+  ],
   "agents_per_node": 5
 }


### PR DESCRIPTION
# Summary

- Removed unnecessary variables that won't change between runs, i.e. scenario-name.
- Remove undesired defaults
- Update the gomplate comment about the defaults to remove the blank line in the generated file
- Rename all variables to use underscores instead of hyphens
- Update the Nomad CI workflow to use the new variable names
- Update README based on changes, i.e., no scenario name and different var names

closes #267

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified Nomad job configuration, standardized parameter names to snake_case, centralized settings into data-driven defaults, and consolidated run identifiers.

- Documentation
  - Updated local Nomad instructions: examples now use snake_case parameters, add an explicit step to generate Nomad jobs before running, and adjusted run command examples accordingly.

- Chores
  - CI workflow streamlined by removing the download step and aligning environment variables and run-id handling with the new configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->