### PR TITLE
fix: use boostrap & signal servers compatible with holochain 0.5.x+

### DIFF
--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -68,7 +68,7 @@ job "{{ (ds "vars").scenario_name }}" {
         driver = "raw_exec"
         config {
           command = "bash"
-          args    = ["-c", "mkdir -p ${NOMAD_ALLOC_DIR}/data/telegraf/metrics/ && hc s clean && echo 1234 | hc s --piped create --in-process-lair network --bootstrap=https://bootstrap.holo.host webrtc wss://sbd.holo.host && echo 1234 | hc s --piped -f 8888 run"]
+          args    = ["-c", "mkdir -p ${NOMAD_ALLOC_DIR}/data/telegraf/metrics/ && hc s clean && echo 1234 | hc s --piped create --in-process-lair network --bootstrap=https://dev-test-bootstrap2.holochain.org webrtc wss://dev-test-bootstrap2.holochain.org && echo 1234 | hc s --piped -f 8888 run"]
         }
 
         resources {


### PR DESCRIPTION
### Summary
Use dev-test bootstrap & signal servers in production runs.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network bootstrap and WebRTC signaling endpoints to the new dev-test service, improving peer discovery and connectivity during scenario runs.
  * Aligns environment configuration with current infrastructure, reducing connection errors and increasing stability in test executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->