### PR TITLE
feat: add ability to start the conductor from wind tunnel nomad

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -105,7 +105,7 @@ jobs:
           NOMAD_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
           NOMAD_VAR_scenario_url: ${{ steps.get-download-url.outputs.download-url }}
           NOMAD_VAR_run_id: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
-          NOMAD_VAR_holochain_bin_url: "${{ inputs.holochain_bin_url }}"
+          NOMAD_VAR_holochain_bin_url: "${{ inputs.holochain_bin_url || 'https://github.com/matthme/holochain-binaries/releases/download/holochain-binaries-0.5.6/holochain-v0.5.6-x86_64-unknown-linux-gnu' }}"
           RUN_ID: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
         run: |-
           set -euo pipefail

--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -100,6 +100,7 @@ jobs:
           NOMAD_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
           NOMAD_VAR_scenario_url: ${{ steps.get-download-url.outputs.download-url }}
           NOMAD_VAR_run_id: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
+          NOMAD_VAR_holochain_bin_url: https://github.com/holochain/wind-tunnel/releases/tag/0.1.0-alpha.1
           RUN_ID: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
         run: |-
           set -euo pipefail

--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -103,7 +103,7 @@ jobs:
           NOMAD_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
           NOMAD_VAR_scenario_url: ${{ steps.get-download-url.outputs.download-url }}
           NOMAD_VAR_run_id: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
-          NOMAD_VAR_holochain_bin_url: "${{ inputs.holochain_bin_url || 'https://github.com/matthme/holochain-binaries/releases/download/holochain-binaries-0.5.6/holochain-v0.5.6-x86_64-unknown-linux-gnu' }}"
+          NOMAD_VAR_holochain_bin_url: "${{ inputs.holochain_bin_url || 'https://github.com/holochain/holochain/releases/latest/download/holochain-x86_64-unknown-linux-gnu' }}"
           RUN_ID: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
         run: |-
           set -euo pipefail

--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -5,8 +5,6 @@ on:
     inputs:
       holochain_bin_url:
         description: "The URL to download the `holochain` binary from"
-        required: true
-        default: https://github.com/matthme/holochain-binaries/releases/download/holochain-binaries-0.5.6/holochain-v0.5.6-x86_64-unknown-linux-gnu
   schedule:
     - cron: "0 0 * * 4" # Run Nomad workflow at 00:00 on Thursdays
 

--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -2,6 +2,11 @@ name: "Run performance tests on Nomad cluster"
 
 on:
   workflow_dispatch:
+    inputs:
+      holochain_bin_url:
+        description: "The URL to download the `holochain` binary from"
+        required: true
+        default: https://github.com/matthme/holochain-binaries/releases/download/holochain-binaries-0.5.6/holochain-v0.5.6-x86_64-unknown-linux-gnu
   schedule:
     - cron: "0 0 * * 4" # Run Nomad workflow at 00:00 on Thursdays
 
@@ -100,7 +105,7 @@ jobs:
           NOMAD_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
           NOMAD_VAR_scenario_url: ${{ steps.get-download-url.outputs.download-url }}
           NOMAD_VAR_run_id: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
-          NOMAD_VAR_holochain_bin_url: https://github.com/holochain/wind-tunnel/releases/tag/0.1.0-alpha.1
+          NOMAD_VAR_holochain_bin_url: "${{ inputs.holochain_bin_url }}"
           RUN_ID: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
         run: |-
           set -euo pipefail

--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -45,20 +45,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Bundle scenario
-        run: |
-          nix bundle .#packages.x86_64-linux.${{ matrix.scenario-name }}
-          cp ./${{ matrix.scenario-name }}-arx ./${{ matrix.scenario-name }}
-
       - name: Build Nomad Job
         run: |
           nix develop --command ./nomad/generate_jobs.sh ${{ matrix.job-name || matrix.scenario-name }}
 
-      - name: Upload bundle as artifact
-        id: upload-bundle
+      - name: Build scenario
+        run: nix build .#packages.x86_64-linux.${{ matrix.scenario-name }}
+
+      - name: Upload scenario as artifact
+        id: upload-scenario
         uses: actions/upload-artifact@v4
         with:
-          path: ./${{ matrix.scenario-name }}
+          path: |
+            ./result/bin/
+            ./result/happs/
           name: ${{ matrix.job-name || matrix.scenario-name }}
           if-no-files-found: error
 
@@ -88,7 +88,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ github.token }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/holochain/wind-tunnel/actions/artifacts/${{ steps.upload-bundle.outputs.artifact-id}}/zip")
+            "https://api.github.com/repos/holochain/wind-tunnel/actions/artifacts/${{ steps.upload-scenario.outputs.artifact-id}}/zip")
           echo "download-url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
 
       - name: Run Nomad Job

--- a/README.md
+++ b/README.md
@@ -490,13 +490,14 @@ nomad agent -dev
 
 Now navigate to <http://localhost:4646/ui> to view the Nomad dashboard.
 
-Next, in a new terminal window, generate the nomad jobs for each scenario with:
+Next, in a new terminal window, generate the nomad job for each scenario by
+passing the scenario name into the `generate_jobs` script, such as:
 
 ```bash
-nix develop --command ./nomad/generate_jobs.sh
+nix develop --command ./nomad/generate_jobs.sh app_install_minimal
 ```
 
-The generated jobs will be in the `nomad/jobs` directory.
+The generated job will be in the `nomad/jobs` directory.
 
 Next, in a new terminal window, build the scenario you want to run with:
 

--- a/README.md
+++ b/README.md
@@ -480,12 +480,14 @@ running a Nomad agent locally as both a client and a server.
 
 First, enter the Nix `devShell` with `nix develop` to make sure you have all the packages install.
 Alternatively, [install Nomad](https://developer.hashicorp.com/nomad/install) and Holochain locally
-so that both `nomad` and `hc` are in your `PATH`.
+so that both `nomad` and `holochain` are in your `PATH`.
 
-Once Nomad is installed, run the agent in `dev` mode to spin up both a server and client, do this with:
+Once Nomad is installed, run the agent with the configuration provided [in this
+repo](nomad/dev-agent-config.hcl) to spin up both a server and client, do this
+with:
 
 ```bash
-nomad agent -dev
+sudo nomad agent -config=nomad/dev-agent-config.hcl
 ```
 
 Now navigate to <http://localhost:4646/ui> to view the Nomad dashboard.
@@ -494,7 +496,7 @@ Next, in a new terminal window, generate the nomad job for each scenario by
 passing the scenario name into the `generate_jobs` script, such as:
 
 ```bash
-nix develop --command ./nomad/generate_jobs.sh app_install_minimal
+./nomad/generate_jobs.sh app_install_minimal
 ```
 
 The generated job will be in the `nomad/jobs` directory.
@@ -519,23 +521,22 @@ All the jobs are in the `nomad/jobs` directory, so you can replace `app_install_
 - `-var scenario_url=...` provides the path to the scenario binary that you built in the previous step.
 - `-var reporter=in-memory` sets the reporter type to print to `stdout` instead of writing an InfluxDB metrics file.
 
-> [!Warning]
-> When running locally as in this guide, the `reporter` must be set to `in-memory` and the `scenario_url` must be a
-> local path due to the way Nomad handles downloading. To get around this limitation you must disable file system
-> isolation, see <https://developer.hashicorp.com/nomad/docs/configuration/client#disable_filesystem_isolation>.
-
 You can also override existing and omitted variables with the `-var` flag. For example, to set the duration (in seconds) use:
 
 ```bash
 nomad job run -address=http://localhost:4646 -var scenario_url=result/bin/app_install -var reporter=in-memory -var duration=300 nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
-> [!Note]
-> Make sure the `var` options are after the `var-file` option otherwise the values in the file will take precedence.
+Or to download and use a different Holochain binary to start the conductors:
 
-Then, navigate to <http://localhost:4646/ui/jobs/run_scenario@default> where you should see one allocation,
-which is the Nomad name for an instance of the job. You can view the logs of the tasks to see the results.
-The allocation should be marked as "complete" after the duration specified.
+```bash
+nomad job run -address=http://localhost:4646 -var scenario_url=result/bin/app_install -var reporter=in-memory -var holochain_bin_url=https://github.com/holochain/holochain/releases/latest/download/holochain-x86_64-unknown-linux-gnu nomad/jobs/app_install_minimal.nomad.hcl
+```
+
+Then, navigate to <http://localhost:4646/ui/jobs> where you should see your job listed, after clicking on
+the job you should see one allocation, which is the Nomad name for an instance of the job. You can view
+the logs of the tasks to see the results. The allocation should be marked as "complete" after the
+duration specified.
 
 Once you've finished testing you can kill the Nomad agent with `^C` in the first terminal running the agent.
 
@@ -569,25 +570,26 @@ The final environment variable that needs to be set and is **not** set by the `d
 which needs to be set to a token with the correct permissions, for now it is fine to just use the admin
 token found in the Holochain shared vault of the password manager under `Nomad Server Bootstrap Token`.
 
-Once Nomad is installed, bundle the scenario you want to run with Nix so that it can run on other machines.
+Once Nomad is installed, build the scenario you want to run with Nix so that it puts everything in the
+correct location for you.
 
 Run:
 
 ```bash
-nix bundle .#packages.x86_64-linux.app_install
+nix build .#packages.x86_64-linux.app_install
 ```
 
 Replace `app_install` with the name of the scenario that you want to run.
-This will build and bundle the scenario to run on any `x86_64-linux` machine and does not require Nix to run.
-The bundled output will be in your `/nix/store/` with a symlink to it in your local dir with an `-arx` postfix,
-to make it easier to find the bundle later it is recommended to copy it somewhere. It is also best to remove
-the `-arx` postfix now so we don't forget later.
+This will build the scenario, the output will be in your `/nix/store/` with a symlink to it in your local
+with the name `./result`, zip the files found in the results directory, keeping the directory structure.
+
+An example to do this is with:
 
 ```bash
-cp ./app_install-arx ./app_install
+mkdir app_install && cp -r result/* app_install/ && cd app_install && zip -r app_install.zip . && cd -
 ```
 
-You now need to upload the scenario bundle to somewhere public so that the Nomad client can download it.
+You now need to upload the scenario zip file to somewhere public so that the Nomad client can download it.
 This could be a GitHub release, a public file sharing services, or some other means, as long as it's publicly
 accessible.
 
@@ -601,14 +603,14 @@ At this point you have to generate the Nomad job for the scenario you want to ru
 ./nomad/generate_jobs.sh app_install_minimal
 ```
 
-Now that the bundle is publicly available you can run the scenario with the following:
+Now that the scenario zip file is publicly available you can run the scenario with the following:
 
 ```bash
-nomad job run -var scenario_url=http://{some-url} nomad/jobs/app_install_minimal.nomad.hcl
+nomad job run -var scenario_url=http://{some-url} -var holochain_bin_url=https://github.com/holochain/holochain/releases/latest/download/holochain-x86_64-unknown-linux-gnu nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
-- `-var-file` should point to the var file, in `nomad/var_files`, of the scenario you want to run.
-- `-var scenario_url=...` provides the URL to the scenario binary that you uploaded in the previous step.
+- `-var scenario_url=...` provides the URL to the scenario zip file that you uploaded in the previous step.
+- `-var holochain_bin_url=...` provides the URL to download the version of the Holochain binary to test.
 
 You can also override existing and omitted variables with the `-var` flag. For example, to set the duration
 (in seconds) or to set the reporter to print to `stdout`.
@@ -617,12 +619,10 @@ You can also override existing and omitted variables with the `-var` flag. For e
 nomad job run -var scenario_url=http://{some-url} -var reporter=in-memory -var duration=300 nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
-> [!Note]
-> Make sure the `var` options are after the `var-file` option otherwise the values in the file will take precedence.
-
-Then, navigate to <https://nomad-server-01.holochain.org:4646/ui/jobs/run_scenario@default> where you
-should see the allocation, which is the Nomad name for an instance of the job. You can view the logs
-of the tasks to see the results. The allocation should be marked as "complete" after the duration specified.
+Then, navigate to <https://nomad-server-01.holochain.org:4646/ui/jobs> where you should see a job with the
+same name as the scenario under test. Clicking on this job should show an allocation, which is the Nomad
+name for an instance of the job. You can view the logs of the tasks to see the results. The allocation
+should be marked as "complete" after the duration specified.
 
 You can now get the run ID from the `stdout` of the `run_scenario` task in the Nomad web UI and, if the `reporter`
 was set to `influx-file` (the default value) then you can use that ID to view the results on the corresponding
@@ -632,7 +632,7 @@ the credentials of which can be found in the Holochain shared vault of the passw
 ###### Running Scenarios with the CI
 
 There is a [dedicated GitHub workflow](https://github.com/holochain/wind-tunnel/actions/workflows/nomad.yaml)
-for bundling all the scenarios designed to run with Nomad, uploading them as GitHub artifacts, and then
+for building all the scenarios designed to run with Nomad, uploading them as GitHub artifacts, and then
 running them on available Nomad clients specifically available for testing. The metrics from the runs
 are also uploaded to the InfluxDB instance. This is the recommended way to run the Wind Tunnel scenarios
 with Nomad.
@@ -641,7 +641,9 @@ To run it, simply navigate to <https://github.com/holochain/wind-tunnel/actions/
 `Run workflow` on the right, and select the branch that you want to test. If you only want to test a
 sub-selection of the scenarios then simply comment-out or remove the scenarios that you want to exclude
 from the matrix in [the workflow file](.github/workflows/nomad.yaml), push your changes and make sure to
-select the correct branch.
+select the correct branch. You can also override the URL to download the Holochain binary from, if you would
+like to test a different version of Holochain, the default is the latest release at
+<https://github.com/holochain/holochain/releases/latest>.
 
 > [!Warning]
 > Currently, the `Wait for free nodes` step will wait indefinitely if there are never enough free nodes

--- a/bindings/runner/src/common.rs
+++ b/bindings/runner/src/common.rs
@@ -674,11 +674,13 @@ pub fn run_holochain_conductor<SV: UserValuesConstraint>(
             .context("Failed to bind ephemeral port for admin interface")?;
         listener.local_addr()?.port()
     };
-    let conductor_root_path = PathBuf::from(format!(
-        "./{}/{}",
-        ctx.runner_context().get_run_id(),
-        ctx.agent_name()
-    ));
+    let conductor_root_path = {
+        let mut path = env::temp_dir();
+        path.push(ctx.runner_context().get_run_id());
+        path.push(ctx.agent_name());
+
+        path
+    };
     let agent_name = ctx.agent_name().to_string();
     ctx.get_mut()
         .holochain_config_mut()

--- a/bindings/runner/src/holochain_runner.rs
+++ b/bindings/runner/src/holochain_runner.rs
@@ -154,18 +154,14 @@ impl HolochainRunner {
     /// process internally so it can be gracefully shutdown and clean up directories on
     /// [`Drop::drop`].
     pub async fn run(config: &HolochainConfig) -> WindTunnelResult<Self> {
-        let conductor_root_path = config
-            .conductor_config_root_path
-            .to_path_buf()
-            .canonicalize()?;
-        if !fs::exists(&conductor_root_path)? {
-            fs::create_dir_all(&conductor_root_path).with_context(|| {
-                format!(
-                    "Failed to create conductor root directory '{}'",
-                    conductor_root_path.display()
-                )
-            })?;
-        }
+        let conductor_root_path = config.conductor_config_root_path.to_path_buf();
+        fs::create_dir_all(&conductor_root_path).with_context(|| {
+            format!(
+                "Failed to create conductor root directory '{}'",
+                conductor_root_path.display()
+            )
+        })?;
+        let conductor_root_path = conductor_root_path.canonicalize()?;
 
         log::trace!(
             "Writing conductor config file to '{}'",

--- a/bindings/runner/src/holochain_runner.rs
+++ b/bindings/runner/src/holochain_runner.rs
@@ -154,7 +154,10 @@ impl HolochainRunner {
     /// process internally so it can be gracefully shutdown and clean up directories on
     /// [`Drop::drop`].
     pub async fn run(config: &HolochainConfig) -> WindTunnelResult<Self> {
-        let conductor_root_path = config.conductor_config_root_path.to_path_buf();
+        let conductor_root_path = config
+            .conductor_config_root_path
+            .to_path_buf()
+            .canonicalize()?;
         if !fs::exists(&conductor_root_path)? {
             fs::create_dir_all(&conductor_root_path).with_context(|| {
                 format!(
@@ -164,6 +167,10 @@ impl HolochainRunner {
             })?;
         }
 
+        log::trace!(
+            "Writing conductor config file to '{}'",
+            conductor_root_path.display()
+        );
         let conductor_config_path = write_config(
             config.conductor_config_root_path.clone(),
             &config.conductor_config,

--- a/nomad/dev-agent-config.hcl
+++ b/nomad/dev-agent-config.hcl
@@ -1,0 +1,19 @@
+data_dir = "/tmp/nomad/data"
+
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+server {
+  enabled          = true
+  bootstrap_expect = 1
+}
+
+client {
+  enabled = true
+  artifact {
+    disable_filesystem_isolation = true
+  }
+}

--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -125,7 +125,7 @@ job "{{ (ds "vars").scenario_name }}" {
 
         config {
           // If `var.scenario_url` is a valid local path then run that. Otherwise run the scenario downloaded by the `artifact` block.
-          command = fileexists(abspath(var.scenario_url)) ? abspath(var.scenario_url) : {{ (ds "vars").scenario_name | quote }}
+          command = fileexists(abspath(var.scenario_url)) ? abspath(var.scenario_url) : "${NOMAD_TASK_DIR}/bin/{{ (ds "vars").scenario_name }}"
           // The `compact` function removes empty strings and `null` items from the list.
           args = compact([
             var.duration != null ? "--duration=${var.duration}" : null,

--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -20,7 +20,7 @@ variable "holochain_bin_url" {
 
 variable "scenario_url" {
   type        = string
-  description = "The URL to the binary or bundle of the scenario under test, this will be downloaded if it is not a local path" 
+  description = "The URL to the local binary or download link to the zip file of the scenario under test"
 }
 
 variable "run_id" {

--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -12,6 +12,11 @@ variable "reporter" {
   default     = {{ index (ds "vars") "reporter" | default "influx-file" | quote }}
 }
 
+variable "holochain_bin_url" {
+  type        = string
+  description = "URL from which to download the `holochain` binary from to start conductors with"
+}
+
 variable "scenario_url" {
   type        = string
   description = "The URL to the binary or bundle of the scenario under test, this will be downloaded if it is not a local path" 
@@ -88,12 +93,17 @@ job "{{ (ds "vars").scenario_name }}" {
           }
         }
 
+        artifact {
+          source = var.holochain_bin_url
+        }
+
         env {
           RUST_LOG          = "info"
           HOME              = "${NOMAD_TASK_DIR}"
           WT_METRICS_DIR    = "${NOMAD_ALLOC_DIR}/data/telegraf/metrics"
           MIN_AGENTS        = "{{ mul (index (ds "vars") "agents_per_node" | default 1) (len (index (ds "vars") "behaviours" | default (coll.Slice "") )) }}"
           RUN_SUMMARY_PATH  = "${NOMAD_ALLOC_DIR}/run_summary.jsonl"
+          WT_HOLOCHAIN_PATH = "${NOMAD_TASK_DIR}/holochain"
         }
 
         config {


### PR DESCRIPTION
### Summary
Closes #161. This changes the Nomad jobs to use the new feature of Wind Tunnel, which allows the scenarios themselves to start a Holochain conductor per agent, see #260.

To achieve this, a URL to a `holochain` binary is now provided when starting the CI job with a default working URL. Then, the scenarios are no longer bundled with `nix bundle` and instead just zipped.

The Nomad job template has been updated to reflect these changes.

This must be merged after holochain/wind-tunnel-runner#22, as that is required to support the running of the `holochain` dynamically-linked binaries.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Allow specifying a Holochain binary URL for scenarios; Nomad jobs download and use it automatically.
  - Scenarios can be fetched as artifacts by URL; execution path standardized and Holochain path exposed to tasks.

- Documentation
  - Updated docs for per-scenario build/run/upload workflow, example commands for packaging/hosting scenarios, and holochain_bin_url usage.

- Refactor
  - Startup flow streamlined to download binaries on-demand and simplified execution flow.
  - Conductor/runtime paths now created and canonicalized earlier to surface errors.

- Chores
  - CI/workflow updated to build and publish scenario artifacts (binaries and happs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->