### PR TITLE
ci: Upload run_summary artifact to github ci

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -182,3 +182,10 @@ jobs:
           RUN_SUMMARY_PATH: ./run_summary.jsonl
           RUST_LOG: debug
         run: nix develop --command cargo run --release --bin holochain-summariser
+
+      - name: Upload run summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: summariser-report
+          if-no-files-found: ignore
+          path: ./summariser-report-*.json


### PR DESCRIPTION
### Summary

- Upload the run_summary.jsonl to Github ci artifacts.

closes #270

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now uploads the summariser run report as an artifact after the summarisation step, improving visibility and retrieval.
  * Upload configured to skip gracefully when no report is produced.
  * No changes to product behavior or public interfaces; impacts CI reporting and traceability only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->