### PR TITLE
ci: don't add changelog preview comment to dependabot PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -306,7 +306,7 @@ jobs:
           path: dist/*
 
   changelog-preview-comment:
-    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'hra-release')
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'hra-release') && github.actor != 'dependabot[bot]'
     name: Add comment of changelog preview
     uses: holochain/actions/.github/workflows/changelog-preview-comment.yml@v1.2.0
 


### PR DESCRIPTION
### Summary

Done to avoid issues with the PRs opened by dependabot, like: https://github.com/holochain/wind-tunnel/actions/runs/18409998285/job/52459484603?pr=252

I can't easily test this, so I hope that it works.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to skip posting changelog preview comments on automated dependency update pull requests, reducing clutter in PR discussions and keeping automation logs cleaner.
  * No changes to application functionality or user-facing features.
  * No impact on release artifacts, runtime behavior, or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->