### PR TITLE
Feat: Wind Tunnel summary visualiser

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -278,6 +278,10 @@ jobs:
           echo
           df -h
 
+      - name: Smoke test - scenario summary HTML visualiser
+        run: |
+          nix run .#summary-visualiser-smoke-test
+
   archive_bundles:
     runs-on: ubuntu-latest
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ lp-tool/lp-tool
 
 # direnv temp directory
 /.direnv
+
+# Summary visualiser output
+*.html

--- a/flake.nix
+++ b/flake.nix
@@ -444,6 +444,16 @@
               RUST_LOG=info cargo run "$@"
             '';
           };
+          summary-visualiser-smoke-test = pkgs.writeShellApplication {
+            name = "summary-visualiser-smoke-test";
+            runtimeInputs = [
+              pkgs.gomplate
+            ];
+            text = ''
+              set -euo pipefail
+              ./summary-visualiser/test.sh
+            '';
+          };
         };
 
         checks = {

--- a/summary-visualiser/README.md
+++ b/summary-visualiser/README.md
@@ -1,0 +1,24 @@
+# Wind Tunnel Summary Visualiser
+
+A tool to take a summary report from a Wind Tunnel scenario run, in JSON format, and turn it into a pretty HTML report with graphs, so you can grok the information more deeply and quickly. It uses [`gomplate`](https://gomplate.ca/) in a bash script to do its work.
+
+## Prerequisites
+
+Either install `jq` and `gomplate`, or run `nix develop` in the repo root to get those tools.
+
+## Usage
+
+The command takes input JSON (either as a filename or from stdin) and outputs to stdout.
+
+```bash
+summary-visualiser/generate.sh foo.json > out.html
+```
+
+### With sample data
+
+This tool (or rather, its template) expects the input JSON to be an array of objects. Use the sample files in `summary-visualiser/test_data/` (rather than the ones in `summariser/test_data/3_summary_outputs/`, which are just bare objects):
+
+```bash
+cd summary-visualiser
+./generate.sh test_data/dht_sync_lag.json > dht_sync_lag.html
+```

--- a/summary-visualiser/TODO.md
+++ b/summary-visualiser/TODO.md
@@ -1,0 +1,14 @@
+# TODO
+
+## Ways to display data
+
+* are `within_?std` values useful, or can we just show `std`?
+* What max precision should we show?
+
+## Metrics that I don't know how to interpret
+
+* `dht_sync_lag`
+    * `sync_lag_rate` -- what is the unit?
+    * `cascade_duration` -- amount of time spent doing cascade queries?
+    * `wasm_usage_total` and sisters -- CPU cycles? RAM?
+    * `authored_db_utilization` and sisters -- what do these numbers mean?

--- a/summary-visualiser/assets/windTunnel.js
+++ b/summary-visualiser/assets/windTunnel.js
@@ -1,0 +1,100 @@
+window.createTrendGraph = function (svgId, trendData, meanValue, windowDuration, yUnit) {
+    // Note: if you change the left margin value,
+    // make sure that the CSS for `.no-trend-graph` in `page.html.tmpl`
+    // gets updated accordingly.
+    const margin = { top: 10, right: 20, bottom: 20, left: 60 };
+    const pointWidth = 10; // Width per data point
+    const width = (trendData.length * pointWidth);
+    const height = 120;
+
+    const svg = d3.select(`#${svgId}`)
+        .attr("width", width + margin.left + margin.right)
+        .attr("height", height + margin.top + margin.bottom)
+        // The guts of the graph go into this `<g>` wrapper,
+        // in order to make the coordinates of the trend data and axis label easy to work with --
+        // they're all zero-referenced to the top-left corner of the graph.
+        // It's then moved to the right position in the SVG to make room for the legends.
+        .append("g")
+        .attr("transform", `translate(${margin.left},${margin.top})`);
+
+    const maxVal = d3.max(trendData);
+
+    // Map time window values to the x range of the graph.
+    const x = d3.scaleLinear()
+        .domain([0, trendData.length - 1])
+        .range([0, width]);
+
+    // Map data point values to the y range of the graph.
+    const y = d3.scaleLinear()
+        .domain([0, maxVal])
+        .range([height, 0]);
+
+    // The trend line.
+    const line = d3.line()
+        .x((d, i) => x(i))
+        .y(d => y(d));
+    svg.append("path")
+        .datum(trendData)
+        .attr("class", "trend-line")
+        .attr("d", line);
+
+    // The area under the trend line.
+    const area = d3.area()
+        .x((d, i) => x(i))
+        .y0(height)
+        .y1(d => y(d));
+    svg.append("path")
+        .datum(trendData)
+        .attr("class", "trend-area")
+        .attr("d", area);
+
+    // Draw the mean line if provided.
+    if (meanValue !== null) {
+        svg.append("line")
+            .attr("class", "mean-line")
+            .attr("x1", 0)
+            .attr("x2", width)
+            .attr("y1", y(meanValue))
+            .attr("y2", y(meanValue));
+    }
+
+    // Y-axis labels -- always zero on the bottom and the max data point value on the top.
+    svg.append("text")
+        .attr("class", "axis-label")
+        .attr("x", -5)
+        .attr("y", 0)
+        .attr("text-anchor", "end")
+        .attr("alignment-baseline", "middle")
+        .text(`${maxVal}${yUnit || ""}`);
+
+    svg.append("text")
+        .attr("class", "axis-label")
+        .attr("x", -5)
+        .attr("y", height)
+        .attr("text-anchor", "end")
+        .attr("alignment-baseline", "middle")
+        .text(`0${yUnit || ""}`);
+
+    // X-axis labels -- 0 seconds at the start,
+    // and the number of data points × the time window duration at the end.
+
+    // Extract numeric and non-numeric parts of windowDuration.
+    const match = windowDuration.match(/^(\d+)(.*)$/);
+    const durationValue = parseInt(match[1]);
+    const durationUnit = match[2];
+    const totalDuration = durationValue * trendData.length;
+
+    svg.append("text")
+        .attr("class", "axis-label")
+        .attr("x", 0)
+        .attr("y", height + 15)
+        .attr("text-anchor", "middle")
+        .text(`0${durationUnit}`);
+
+    svg.append("text")
+        .attr("class", "axis-label")
+        .attr("x", width)
+        .attr("y", height + 15)
+        .attr("text-anchor", "middle")
+        .text(`${totalDuration}${durationUnit}`);
+};

--- a/summary-visualiser/generate.sh
+++ b/summary-visualiser/generate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+script_dir=$(dirname "$0")
+
+# Get all the helper templates and make them available to gomplate
+# via their unadorned filename
+# (e.g., `delta` not `templates/helpers/delta.html.tmpl`).
+template_args=()
+for template_dir in "helpers" "scenarios" ; do
+    for helper_file in "$script_dir/templates/$template_dir/"*.html.tmpl; do
+        [ -e "$helper_file" ] || continue
+        helper_name=$(basename "$helper_file" .html.tmpl)
+        template_args+=(-t "$helper_name=$helper_file")
+    done
+done
+
+# This command does three things worth noting:
+# * Accept either a filename or stdin
+# * Add the JS file as a helper template so that it can be inlined into the page
+# * Set up a helper plugin to test whether a template exists for a given scenario
+#   (note: this requires `SCENARIO_TEMPLATES_DIR` to be set)
+SCENARIO_TEMPLATES_DIR="$script_dir/templates/scenarios" gomplate \
+    -c .="${1:-stdin:///in.json}" \
+    -t js="$script_dir/assets/windTunnel.js" \
+    "${template_args[@]}" \
+    --plugin scenario_template_exists="$script_dir/scenario_template_exists.sh" \
+    -f "$script_dir/templates/page.html.tmpl"

--- a/summary-visualiser/scenario_template_exists.sh
+++ b/summary-visualiser/scenario_template_exists.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    echo "Error: scenario name argument required" >&2
+    exit 1
+fi
+
+if [ -f "$SCENARIO_TEMPLATES_DIR/$1.html.tmpl" ]; then
+    echo "1"
+fi

--- a/summary-visualiser/templates/helpers/dbConnection.html.tmpl
+++ b/summary-visualiser/templates/helpers/dbConnection.html.tmpl
@@ -1,0 +1,13 @@
+{{ if .utilization }}
+    {{ template "scenarioMetricContentItem" (dict
+        "name" "Utilisation"
+        "content" (tmpl.Exec "meanMax" (dict
+            "mean" .utilization.mean
+            "max" .utilization.max
+            "unit" "%"
+        ))
+    ) }}
+{{ end }}
+{{ if .use_time }}
+    {{ template "dbConnectionUseTime" .use_time }}
+{{ end }}

--- a/summary-visualiser/templates/helpers/dbConnectionUseTime.html.tmpl
+++ b/summary-visualiser/templates/helpers/dbConnectionUseTime.html.tmpl
@@ -1,0 +1,16 @@
+{{ template "scenarioMetricContentItem" (dict
+    "name" "Use time"
+    "content" (print
+        (tmpl.Exec "meanStd" (dict
+            "mean" .mean
+            "std" .std
+            "unit" "s"
+        ))
+        (tmpl.Exec "trendGraph" (dict
+            "data" .trend.trend
+            "mean" .mean
+            "window_duration" .trend.window_duration
+            "unit" "s"
+        ))
+    )
+) }}

--- a/summary-visualiser/templates/helpers/delta.html.tmpl
+++ b/summary-visualiser/templates/helpers/delta.html.tmpl
@@ -1,0 +1,30 @@
+<span class="delta">
+    <span class="delta-start-end">
+        <span class="delta-start">
+            {{- template "scalar" (dict "value" .start "unit" (or (index . "unit") nil)) -}}
+        </span>
+        {{ if (lt .start .end) }}
+            <span class="delta-dir delta-dir-up">&#x2B06;</span>
+        {{ else if (gt .start .end) }}
+            <span class="delta-dir delta-dir-down">&#x2B07;</span>
+        {{ end }}
+        {{ if (ne .start .end) }}
+            <span class="delta-end">
+                {{- template "scalar" (dict "value" .end "unit" (or (index . "unit") nil)) -}}
+            </span>
+        {{ end }}
+    </span>
+
+    {{ if (and .start .end (ne .start .end)) }}
+        {{/* Start and end must be non-zero and not equal to each other for a percent change to make sense */}}
+        <span class="delta-change">
+            <span class="delta-percent-change">change:
+                {{ template "scalar" (dict
+                    "value" (math.Mul (math.Div (math.Sub .end .start) .start) 100)
+                    "unit" "%"
+                ) -}}
+            </span>
+            <span class="delta-measurement-duration">over {{ .measurement_duration }}s ({{- template "scalar" (dict "value" .ratePerSecond "unit" (or (index . "unit") nil)) -}}/s)</span>
+        </span>
+    {{ end }}
+</span>

--- a/summary-visualiser/templates/helpers/meanMax.html.tmpl
+++ b/summary-visualiser/templates/helpers/meanMax.html.tmpl
@@ -1,0 +1,10 @@
+<div class="mean-max">
+    <span class="mean-max-mean">
+        {{- template "scalar" (dict "value" .mean "unit" (or (index . "unit") nil)) -}}
+    </span>
+    {{ if (ne .mean .max) }}
+        <span class="mean-max-max">(max
+            {{ template "scalar" (dict "value" .max "unit" (or (index . "unit") nil)) -}})
+        </span>
+    {{ end }}
+</div>

--- a/summary-visualiser/templates/helpers/meanStd.html.tmpl
+++ b/summary-visualiser/templates/helpers/meanStd.html.tmpl
@@ -1,0 +1,8 @@
+<div class="mean-std">
+    <span class="mean-std-mean">
+        {{- template "scalar" (dict "value" .mean "unit" (or (index . "unit") nil)) -}}
+    </span>
+    <span class="mean-std-std">(SD =
+        {{ template "scalar" (dict "value" .std "unit" (or (index . "unit") nil)) -}})
+    </span>
+</div>

--- a/summary-visualiser/templates/helpers/scalar.html.tmpl
+++ b/summary-visualiser/templates/helpers/scalar.html.tmpl
@@ -1,0 +1,1 @@
+<span class="scalar"><span class="scalar-value">{{ .value }}</span>{{ if (index . "unit") }}<span class="scalar-unit">{{ .unit }}</span>{{ end }}</span>

--- a/summary-visualiser/templates/helpers/scenarioMetric.html.tmpl
+++ b/summary-visualiser/templates/helpers/scenarioMetric.html.tmpl
@@ -1,0 +1,11 @@
+<div class="scenario-metric">
+    <div class="scenario-metric-label">
+        <div class="scenario-metric-name">{{ .name }}</div>
+        {{ if (index . "description") }}
+            <div class="scenario-metric-description">{{ .description }}</div>
+        {{ end }}
+    </div>
+    <div class="scenario-metric-content">
+        {{ .content }}
+    </div>
+</div>

--- a/summary-visualiser/templates/helpers/scenarioMetricContentItem.html.tmpl
+++ b/summary-visualiser/templates/helpers/scenarioMetricContentItem.html.tmpl
@@ -1,0 +1,11 @@
+<div class="scenario-metric-content-item">
+    <div class="scenario-metric-content-item-label">
+        <div class="scenario-metric-content-item-name">{{ .name }}</div>
+        {{ if (index . "description") }}
+            <div class="scenario-metric-content-item-description">{{ .description }}</div>
+        {{ end }}
+    </div>
+    <div class="scenario-metric-content-item-content">
+        {{ .content }}
+    </div>
+</div>

--- a/summary-visualiser/templates/helpers/scenarioSummary.html.tmpl
+++ b/summary-visualiser/templates/helpers/scenarioSummary.html.tmpl
@@ -1,0 +1,40 @@
+<div class="scenario-summary">
+    <h1>{{ .title }}</h1>
+
+    <div class="scenario-summary-description">{{ .description }}</div>
+
+    <div class="scenario-summary-details">
+        <div class="scenario-summary-details-line">
+            <div class="scenario-summary-details-label">Started</div>
+            <div class="scenario-summary-details-value">{{ (time.Unix .data.started_at).Format time.RFC1123 }}</div>
+        </div>
+
+        {{ if .data.run_duration }}
+            <div class="scenario-summary-details-line">
+                <div class="scenario-summary-details-label">Duration</div>
+                <div class="scenario-summary-details-value">{{ .data.run_duration }}s</div>
+            </div>
+        {{ end }}
+
+        <div class="scenario-summary-details-line">
+            <div class="scenario-summary-details-label">Behaviours</div>
+            <div class="scenario-summary-details-value">
+                <ul class="scenario-summary-assigned-behaviours">
+                    {{ range $behaviour, $count := .data.assigned_behaviours }}
+                        <li><code>{{ $behaviour }}</code>: {{ $count }} agent{{ if (ne $count 1) }}s{{ end }}</li>
+                    {{ end }}
+                </ul>
+            </div>
+        </div>
+
+        <div class="scenario-summary-details-line">
+            <div class="scenario-summary-details-label">Wind Tunnel version</div>
+            <div class="scenario-summary-details-value">{{ .data.wind_tunnel_version }}</div>
+        </div>
+
+        <div class="scenario-summary-details-line">
+            <div class="scenario-summary-details-label">Run ID</div>
+            <div class="scenario-summary-details-value">{{ .data.run_id }}</div>
+        </div>
+    </div>
+</div>

--- a/summary-visualiser/templates/helpers/scenariosLoop.html.tmpl
+++ b/summary-visualiser/templates/helpers/scenariosLoop.html.tmpl
@@ -1,0 +1,12 @@
+{{/* Loop through an array of scenarios and render them,
+choosing the proper template for each. */}}
+{{ range . }}
+    {{/* The proper scenario-specific template name is a field in the run_summary object.
+    Extract that and use `tmpl.Exec` cuz it can take a template name from a pipeline,
+    whereas `template` seems to require a string literal. */}}
+    {{ if (scenario_template_exists .run_summary.scenario_name) }}
+        {{ tmpl.Exec .run_summary.scenario_name . }}
+    {{ else }}
+        <p>No scenario template for <code>{{ .run_summary.scenario_name }}</code>!</p>
+    {{ end }}
+{{ end }}

--- a/summary-visualiser/templates/helpers/scenariosTitle.html.tmpl
+++ b/summary-visualiser/templates/helpers/scenariosTitle.html.tmpl
@@ -1,0 +1,2 @@
+{{/* Create a useful title from a list of scenarios. */}}
+{{- conv.Join (coll.Uniq (coll.JQ "map(.run_summary.scenario_name)" .)) ", " -}}

--- a/summary-visualiser/templates/helpers/trendGraph.html.tmpl
+++ b/summary-visualiser/templates/helpers/trendGraph.html.tmpl
@@ -1,0 +1,10 @@
+{{ if (and .data (gt (len .data) 1)) }}
+    {{ $svgId := random.AlphaNum 16 }}
+    <div class="trend-graph">
+        <svg id="trend-svg-{{ $svgId }}"></svg>
+    </div>
+
+    <script>createTrendGraph("trend-svg-{{ $svgId }}", [{{ conv.Join .data ", " }}], {{ .mean }}, "{{ .window_duration }}", "{{ or (index . "unit") "" }}");</script>
+{{ else }}
+    <div class="no-trend-graph">No trend data available.</div>
+{{ end }}

--- a/summary-visualiser/templates/page.html.tmpl
+++ b/summary-visualiser/templates/page.html.tmpl
@@ -1,0 +1,211 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8"/>
+        <title>{{ template "scenariosTitle" . }} | Wind Tunnel Report</title>
+        <style>
+        :root {
+            --subtle: rgba(0, 0, 0, 0.5);
+            --more-subtle: rgba(0, 0, 0, 0.35);
+            --smoke: rgba(0, 0, 0, 0.2);
+            --good: rgb(0, 173, 12);
+            --bad: rgb(195, 25, 25);
+            --highlight: rgb(52, 152, 219);
+            --highlight-subtle: rgba(52, 152, 219, 0.5);
+            --grid: 0.5fr 1fr;
+            --grid-gap: 2rem;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: #f5f5f5;
+            margin: 0;
+            padding: 20px;
+        }
+
+        main {
+            max-width: 1000px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            padding: 30px;
+        }
+
+        /* Scenario summary */
+
+        .scenario-summary {
+            margin-bottom: 4em;
+        }
+
+        .scenario-summary-description {
+            font-size: 1.25em;
+            color: var(--subtle);
+            margin: 2em 0;
+        }
+
+        .scenario-summary-details-line {
+            display: grid;
+            grid-template-columns: var(--grid);
+            gap: var(--grid-gap);
+        }
+
+        .scenario-summary-details-label {
+            text-align: right;
+            color: var(--subtle);
+        }
+
+        .scenario-summary-details-value {
+            font-weight: bold;
+        }
+
+        .scenario-summary-assigned-behaviours {
+            margin-top: 0;
+            margin-bottom: 0;
+            padding-left: 15px;
+        }
+
+        /* Metric structure */
+
+        .scenario-metric {
+            display: grid;
+            grid-template-columns: var(--grid);
+            align-items: center;
+            gap: var(--grid-gap);
+            border-width: 2px;
+        }
+
+        .scenario-metric, .scenario-metric-content-item {
+            margin: 1em 0;
+            width: 100%;
+        }
+
+        .scenario-metric, .scenario-metric-content-item:not(:first-child) {
+            padding-top: 1em;
+            border-top-style: solid;
+            border-color: var(--smoke);
+        }
+
+        .scenario-metric-content-item {
+            border-width: 1px;
+        }
+
+        .scenario-metric-content-item:first-child {
+            margin-top: 0;
+        }
+
+        .scenario-metric-label, .scenario-metric-content-item-label {
+            color: var(--subtle);
+        }
+
+        .scenario-metric-name {
+            font-size: 1.25em;
+            font-weight: bold;
+        }
+
+        .scenario-metric-label {
+            text-align: right;
+        }
+
+        /* The data for a metric */
+        .scenario-metric-content:not(:has(.scenario-metric-content-item)),
+        .scenario-metric-content-item-content {
+            position: relative;
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            gap: 1em;
+        }
+
+        /*** Widgets ***/
+
+        .scalar-value {
+            font-size: 2rem;
+            font-weight: 600;
+        }
+
+        /* Supplementary numbers shouldn't be so big. */
+        .mean-std-std .scalar-value,
+        .mean-max-max .scalar-value,
+        .delta-change .scalar-value {
+            font-size: inherit;
+        }
+
+        /* These are spans in the markup, but we want them to be block elements. */
+        .mean-std > *, .mean-max > * {
+            display: block;
+        }
+
+        .delta-start-end {
+            display: flex;
+            align-items: center;
+        }
+
+        .delta-change {
+            display: block;
+        }
+
+        .delta-dir {
+            color: var(--more-subtle);
+            font-size: 2em;
+        }
+
+        /* Many metrics contain both a scalar and a trend graph.
+        In those cases, make sure all the scalars are the same width
+        so the following graph lines up. */
+        .scenario-metric-content .scalar:first-child,
+        .scenario-metric-content .mean-std:first-child,
+        .scenario-metric-content .mean-max:first-child,
+        .scenario-metric-content-item-content .scalar:first-child,
+        .scenario-metric-content-item-content .mean-std:first-child,
+        .scenario-metric-content-item-content .mean-max:first-child {
+            width: 10em;
+        }
+
+        /*** Graph SVG ***/
+
+        /* Axis labels for a graph */
+        .axis-label {
+            font-size: 11px;
+            fill: var(--subtle);
+        }
+
+        /* The line in a trend graph */
+        .trend-line {
+            fill: none;
+            stroke: var(--highlight);
+            stroke-width: 2;
+        }
+
+        /* The area under the trend line */
+        .trend-area {
+            fill: var(--smoke);
+            opacity: 0.2;
+        }
+
+        /* The mean line in a trend graph */
+        .mean-line {
+            stroke: var(--highlight-subtle);
+            stroke-width: 2;
+            stroke-dasharray: 3, 3;
+        }
+
+        /* To line up with the start of the graph, indent the "no trend data available" note.
+        This is a bit of a hard-coded hack based on our knowledge that the JS gives 60px for the Y axis labels. */
+        .no-trend-graph {
+            margin-left: 60px;
+            color: var(--subtle);
+        }
+        </style>
+
+        <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+
+        <script>
+            {{ template "js" }}
+        </script>
+    </head>
+
+    <body><main>
+        {{ template "scenariosLoop" . }}
+    </main></body>
+</html>

--- a/summary-visualiser/templates/scenarios/README.md
+++ b/summary-visualiser/templates/scenarios/README.md
@@ -1,0 +1,80 @@
+# Scenario template format
+
+The scenario files in this folder need to be kept in a particular format:
+
+* The file must be named `<scenario_name>.html.tmpl` so the HTML generator tool can match a scenario to a template.
+* The HTML markup must follow a particular structure because it will eventually get <!-- TODO: remove this to "gets" when this happens --> reused on the holochain.org website, which needs to be able to apply CSS rules predictably. Details in the following section.
+
+## Scenario structure
+
+In order to style the scenarios in a consistent way in different contexts (e.g., standalone pages plus the holochain.org website), there are some classnames that you should use. Here's a basic structure for a scenario called `foo`:
+
+```html
+<section class="scenario scenario-foo">
+    <div class="scenario-summary"><!-- hint: use the `scenarioSummary` helper -->
+        <h1>Foo</h1>
+        <div class="scenario-summary-description">
+            <p>Test the speed of foo across multiple nodes.</p>
+        </div>
+
+        <!-- key/value pairs -->
+        <div class="scenario-summary-details">
+            <div class="scenario-summary-details-line">
+                <div class="scenario-summary-details-label">Label 1</div>
+                <div class="scenario-summary-details-value">Value 1</div>
+            </div>
+
+            <div class="scenario-summary-details-line">
+                <div class="scenario-summary-details-label">Label 2</div>
+                <div class="scenario-summary-details-value">Value 2</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="scenario-metrics">
+        <!-- A single scalar value -->
+        <div class="scenario-metric"><!-- hint use the `scenarioMetric` helper -->
+            <div class="scenario-metric-label">
+                <div class="scenario-metric-name">Rate of foo</div>
+                <div class="scenario-metric-description">A measurement of the number of foos processed per second.</div>
+            </div>
+
+            <div class="scenario-metric-content">
+                <span class="scalar"><span class="scalar-value">31.624</span><span class="scalar-unit"> foos/s</span></span><!-- hint: use the `scalar` helper -->
+            </div>
+        </div>
+
+        <!-- Multiple values in one metric -->
+        <div class="scenario-metric">
+            <div class="scenario-metric-label">
+                <div class="scenario-metric-name">Foos per agent</div>
+                <div class="scenario-metric-description">A measurement of the number of foos processed per second, broken down by each agent.</div>
+            </div>
+
+            <div class="scenario-metric-content">
+                <div class="scenario-metric-content-item"><!-- hint: use the `scenarioMetricContentItem` helper -->
+                    <div class="scenario-metric-content-item-label">
+                        <div class="scenario-metric-content-item-name">Alice</div>
+                        <div class="scenario-metric-content-item-description">Agent 1, full arc</div>
+                    </div>
+                    <div class="scenario-metric-content-item-content">
+                        <span class="scalar"><span class="scalar-value">48.246</span><span class="scalar-unit"> foos/s</span></span>
+                    </div>
+                </div>
+
+                <div class="scenario-metric-content-item">
+                    <div class="scenario-metric-content-item-label">
+                        <div class="scenario-metric-content-item-name">Bob</div>
+                        <div class="scenario-metric-content-item-description">Agent 2, zero arc</div>
+                    </div>
+                    <div class="scenario-metric-content-item-content">
+                        <span class="scalar"><span class="scalar-value">24.118</span><span class="scalar-unit"> foos/s</span></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+```
+
+That's the basic markup structure of a scenario. You can explore all the helper templates in `templates/helpers/` for other widgets such as mean + std deviation, mean + max, delta over measured interval, and a nice trend graph.

--- a/summary-visualiser/templates/scenarios/dht_sync_lag.html.tmpl
+++ b/summary-visualiser/templates/scenarios/dht_sync_lag.html.tmpl
@@ -1,0 +1,344 @@
+{{/* The description is a 'partial' that gets passed to the `scenarioSummary` template.
+We could pass it as a string literal instead, but this is nicer
+because your code editor's syntax highlighter can make it look more legible. */}}
+{{- define "description" }}
+<p>Measure lag time between an agent publishing data and other peers being able to see it. This scenario has two roles:</p>
+
+<ul>
+    <li><b><code>write</code></b>: A simple job that just creates entries with a timestamp field. Those entries are linked to a known base hash. For each write, the metric <code>ws.custom.dht_sync_sent_count</code> is incremented.</li>
+    <li><b><code>record_lag</code></b>: A job that repeatedly queries for links from the known base hash. It keeps track of records that it has seen and when a new record is found, and calculates the time difference between the timestamp of the new record and the current time. That time difference is then recorded as a custom metric called <code>wt.custom.dht_sync_lag</code>.</li>
+</ul>
+
+<p>After each behaviour loop the metric <code>ws.custom.dht_sync_recv_count</code> is incremented.</p>
+{{ end -}}
+
+{{/* This helper template gets used further down, in the "WASM usage" metric line.
+It's a separate template because it needs to be concatenated with other templates
+into a content block that gets passed to the scenarioMetric template call.
+In most cases we just call `tmpl.Exec` with a metric,
+but in this case we need to loop over an array of function calls,
+and there's no function equivalent to `range` like there is for `template`/`tmpl.Exec`. */}}
+{{ define "wasm_usage_by_fn" }}
+    {{ range $key, $data := . }}
+        {{ template "scenarioMetricContentItem" (dict
+            "name" $key
+            "content" (tmpl.Exec "delta" (dict
+                "start" $data.start
+                "end" $data.end
+                "measurement_duration" (math.Add $data.measurement_duration.secs (math.Div $data.measurement_duration.nanos 1000000000))
+                "ratePerSecond" $data.rate_per_second
+            ))
+        ) }}
+    {{ end }}
+{{ end }}
+
+{{/* Same situation here, for the authored DB utilisation. */}}
+{{ define "authored_db_utilization" }}
+    {{ range $name, $value := . }}
+        {{ template "scenarioMetricContentItem" (dict
+            "name" (print "Utilisation for " $name)
+            "content" (tmpl.Exec "meanMax" (dict
+                "mean" $value.mean
+                "max" $value.max
+                "unit" "%"
+            ))
+        ) }}
+    {{ end }}
+{{ end }}
+
+{{/* And for countersigning agents. */}}
+{{ define "countersigning_workflow_duration" }}
+    {{ range $agent, $value := .}}
+        {{ template "scenarioMetricContentItem" (dict
+            "name" $agent
+            "content" (print
+                (tmpl.Exec "meanStd" (dict
+                    "mean" $value.mean
+                    "std" $value.std
+                    "unit" "s"
+                ))
+                (tmpl.Exec "trendGraph" (dict
+                    "mean" $value.mean
+                    "data" $value.trend.trend
+                    "unit" "s"
+                    "window_duration" $value.trend.window_duration
+                ))
+            )
+        )}}
+    {{ end }}
+{{ end }}
+
+<section class="scenario scenario-dht-sync-lag">
+    {{ template "scenarioSummary" (dict
+        "title" "DHT Sync Lag"
+        "description" (tmpl.Exec "description")
+        "data" .run_summary
+    ) }}
+
+    <div class="scenario-metrics">
+        {{ with .scenario_metrics }}
+            {{ with (index .create_rate.rates 0).summary_rate }}
+                {{ template "scenarioMetric" (dict
+                    "name" "Create rate"
+                    "description" (print `The average number of created records per agent per ` .window_duration ` window.`)
+                    "content" (print
+                        (tmpl.Exec "scalar" (dict
+                            "value" .mean
+                            "unit" " ops/s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend
+                            "mean" .mean
+                            "window_duration" .window_duration
+                            "unit" " ops/s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ with (index .sync_lag_timing.timings 0).summary_timing }}
+                {{ template "scenarioMetric" (dict
+                    "name" "Sync lag timing"
+                    "description" (print `The average time between when a record was created and when it is first seen by an agent per ` .trend.window_duration ` window.`)
+                    "content" (print
+                        (tmpl.Exec "meanStd" (dict
+                            "mean" .mean
+                            "std" .std
+                            "unit" "s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend.trend
+                            "mean" .mean
+                            "window_duration" .trend.window_duration
+                            "unit" "s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ with (index .sync_lag_rate.rates 0).summary_rate }}
+                {{ template "scenarioMetric" (dict
+                    "name" "Sync lag rate"
+                    "description" (print `The average number of created records discovered per agent per ` .window_duration ` window.`)
+                    "content" (print
+                        (tmpl.Exec "scalar" (dict
+                            "value" .mean
+                            "unit" " count/s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend
+                            "mean" .mean
+                            "window_duration" .window_duration
+                            "unit" " count/s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ template "scenarioMetric" (dict
+                "name" "Error count"
+                "description" "The number of errors encountered during the scenario."
+                "content" (tmpl.Exec "scalar" (dict "value" .error_count))
+            ) }}
+
+            {{ with .cascade_duration }}
+                {{ template "scenarioMetric" (dict
+                    "name" "Cascade duration"
+                    "description" "The time taken to execute a cascade query."
+                    "content" (print
+                        (tmpl.Exec "meanStd" (dict
+                            "mean" .mean
+                            "std" .std
+                            "unit" "s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend.trend
+                            "mean" .mean
+                            "window_duration" .trend.window_duration
+                            "unit" "s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ if (or .wasm_usage_total .wasm_usage_by_fn) }}
+                {{ template "scenarioMetric" (dict
+                    "name" "WASM usage"
+                    "description" "The metered usage of a wasm ribosome."
+                    "content" (print
+                        (default "" (and .wasm_usage_total (tmpl.Exec "scenarioMetricContentItem" (dict
+                            "name" "Total"
+                            "content" (tmpl.Exec "delta" (dict
+                                "start" .wasm_usage_total.start
+                                "end" .wasm_usage_total.end
+                                "measurement_duration" (math.Add .wasm_usage_total.measurement_duration.secs (math.Div .wasm_usage_total.measurement_duration.nanos 1000000000))
+                                "ratePerSecond" .wasm_usage_total.rate_per_second
+                            ))
+                        ))))
+                        (default "" (and .wasm_usage_by_fn (tmpl.Exec "wasm_usage_by_fn" .wasm_usage_by_fn)))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ with .post_commit_duration }}
+                {{ template "scenarioMetric" (dict
+                    "name" "<code>post_commit</code> duration"
+                    "description" "The time spent executing a post commit."
+                    "content" (print
+                        (tmpl.Exec "meanStd" (dict
+                            "mean" .mean
+                            "std" .std
+                            "unit" "s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend.trend
+                            "mean" .mean
+                            "window_duration" .trend.window_duration
+                            "unit" "s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ with .publish_dht_ops_workflow_duration }}
+                {{ template "scenarioMetric" (dict
+                    "name" "Publish DHT ops workflow duration"
+                    "description" "The time spent running the publish workflow."
+                    "content" (print
+                        (tmpl.Exec "meanStd" (dict
+                            "mean" .mean
+                            "std" .std
+                            "unit" "s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend.trend
+                            "mean" .mean
+                            "window_duration" .trend.window_duration
+                            "unit" "s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ with .integrate_dht_ops_workflow_duration }}
+                {{ template "scenarioMetric" (dict
+                    "name" "Integrate DHT ops workflow duration"
+                    "description" "The time spent running the integration workflow."
+                    "content" (print
+                        (tmpl.Exec "meanStd" (dict
+                            "mean" .mean
+                            "std" .std
+                            "unit" "s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend.trend
+                            "mean" .mean
+                            "window_duration" .trend.window_duration
+                            "unit" "s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ with .countersigning_workflow_duration }}
+                {{ template "scenarioMetric" (dict
+                    "name" "Countersigning workflow duration"
+                    "content" (tmpl.Exec "countersigning_workflow_duration" .)
+                ) }}
+            {{ end }}
+
+            {{ with .app_validation_workflow_duration }}
+                {{ template "scenarioMetric" (dict
+                    "name" "App validation workflow duration"
+                    "description" "The time spent running the app validation workflow."
+                    "content" (print
+                        (tmpl.Exec "meanStd" (dict
+                            "mean" .mean
+                            "std" .std
+                            "unit" "s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend.trend
+                            "mean" .mean
+                            "window_duration" .trend.window_duration
+                            "unit" "s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ with .system_validation_workflow_duration }}
+                {{ template "scenarioMetric" (dict
+                    "name" "System validation workflow duration"
+                    "description" "The time spent running the sys validation workflow."
+                    "content" (print
+                        (tmpl.Exec "meanStd" (dict
+                            "mean" .mean
+                            "std" .std
+                            "unit" "s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend.trend
+                            "mean" .mean
+                            "window_duration" .trend.window_duration
+                            "unit" "s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ with .validation_receipt_workflow_duration }}
+                {{ template "scenarioMetric" (dict
+                    "name" "Validation receipt workflow duration"
+                    "description" "The time spent running the validation receipt workflow."
+                    "content" (print
+                        (tmpl.Exec "meanStd" (dict
+                            "mean" .mean
+                            "std" .std
+                            "unit" "s"
+                        ))
+                        (tmpl.Exec "trendGraph" (dict
+                            "data" .trend.trend
+                            "mean" .mean
+                            "window_duration" .trend.window_duration
+                            "unit" "s"
+                        ))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ if (or .authored_db_utilization .authored_db_connection_use_time )}}
+                {{ template "scenarioMetric" (dict
+                    "name" "Authored DB"
+                    "description" "The utilization of connections in the authored database connection pool."
+                    "content" (print
+                        (default "" (and .authored_db_utilization (tmpl.Exec "authored_db_utilization" .authored_db_utilization)))
+                        (default "" (and .authored_db_connection_use_time (tmpl.Exec "dbConnectionUseTime" .authored_db_connection_use_time)))
+                    )
+                ) }}
+            {{ end }}
+
+            {{ if (or .conductor_db_utilization .conductor_db_connection_use_time) }}
+                {{ template "scenarioMetric" (dict
+                    "name" "Conductor DB"
+                    "description" "The utilization of connections in the conductor database connection pool."
+                    "content" (tmpl.Exec "dbConnection" (dict
+                        "utilization" .conductor_db_utilization
+                        "use_time" .conductor_db_connection_use_time
+                    ))
+                ) }}
+            {{ end }}
+
+            {{ if (or .dht_db_utilization .dht_db_connection_use_time) }}
+                {{ template "scenarioMetric" (dict
+                    "name" "DHT DB"
+                    "description" "The utilization of connections in the DHT database connection pool."
+                    "content" (tmpl.Exec "dbConnection" (dict
+                        "utilization" .dht_db_utilization
+                        "use_time" .dht_db_connection_use_time
+                    ))
+                ) }}
+            {{ end }}
+        {{ end }}
+    </div>
+</section>

--- a/summary-visualiser/test.sh
+++ b/summary-visualiser/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This test tries to run the script and look for an expected HTML element that
+# shows that a template could be found for the scenario type given in the JSON.
+
+script_dir=$(dirname "$0")
+
+test_output() {
+    html_output=$(echo "$1" | "$script_dir/generate.sh")
+    expected_element_in_output=$(echo "$html_output" | grep '<section class="scenario scenario-dht-sync-lag">')
+    if [ -n "$expected_element_in_output" ]; then
+        echo "Found expected .scenario-dht-sync-lag element in output for $2"
+    else
+        echo "Couldn't find expected .scenario-dht-sync-lag element in output for $2"
+        exit 1
+    fi
+}
+
+test_output "[$(cat "$script_dir/../summariser/test_data/3_summary_outputs/dht_sync_lag-3a1e33ccf661bd873966c539d4d227e703e1496fb54bb999f7be30a3dd493e51.json")]" "well-populated sample JSON"
+test_output "$(cat "$script_dir/test_data/dht_sync_lag.json")" "real JSON snapshot with some null metrics"

--- a/summary-visualiser/test_data/dht_sync_lag.json
+++ b/summary-visualiser/test_data/dht_sync_lag.json
@@ -1,0 +1,379 @@
+[
+  {
+    "run_summary": {
+      "run_id": "dht_sync_lag_19305188956",
+      "scenario_name": "dht_sync_lag",
+      "started_at": 1762970936,
+      "run_duration": null,
+      "peer_count": 2,
+      "peer_end_count": 2,
+      "assigned_behaviours": {
+        "record_lag": 1,
+        "write": 1
+      },
+      "env": {},
+      "wind_tunnel_version": "0.5.0-dev.0"
+    },
+    "scenario_metrics": {
+      "create_rate": {
+        "mean": 160.24,
+        "rates": [
+          {
+            "key": [
+              {
+                "key": "agent",
+                "value": "uhCAkWEmsTiOmyRS5gQi8SmOoL_YEkVZyp8V7cRwJUOjlOv-3kHyS"
+              }
+            ],
+            "summary_rate": {
+              "mean": 160.24,
+              "trend": [
+                306,
+                262,
+                231,
+                214,
+                187,
+                182,
+                155,
+                147,
+                138,
+                136,
+                128,
+                118,
+                110,
+                108,
+                104,
+                100,
+                98
+              ],
+              "window_duration": "10s"
+            }
+          }
+        ]
+      },
+      "sync_lag_timing": {
+        "mean": 81.504738,
+        "mean_std_dev": 40.884491,
+        "timings": [
+          {
+            "key": [
+              {
+                "key": "agent",
+                "value": "uhCAk8sbKQUQSfheg1ucjCaL13i-3NapCFIgn3OisT2Euj7ibrFpc"
+              }
+            ],
+            "summary_timing": {
+              "mean": 81.504738,
+              "std": 40.884491,
+              "within_std": 0.5789,
+              "within_2std": 0.9474,
+              "within_3std": 1.0,
+              "trend": {
+                "trend": [
+                  68.732717,
+                  151.346711
+                ],
+                "window_duration": "10s"
+              }
+            }
+          }
+        ]
+      },
+      "sync_lag_rate": {
+        "mean": 0.0,
+        "rates": [
+          {
+            "key": [
+              {
+                "key": "agent",
+                "value": "uhCAk8sbKQUQSfheg1ucjCaL13i-3NapCFIgn3OisT2Euj7ibrFpc"
+              }
+            ],
+            "summary_rate": {
+              "mean": 0.0,
+              "trend": [],
+              "window_duration": "10s"
+            }
+          }
+        ]
+      },
+      "error_count": 0,
+      "cascade_duration": null,
+      "wasm_usage_total": null,
+      "wasm_usage_by_fn": null,
+      "post_commit_duration": null,
+      "publish_dht_ops_workflow_duration": null,
+      "integrate_dht_ops_workflow_duration": null,
+      "countersigning_workflow_duration": null,
+      "app_validation_workflow_duration": null,
+      "system_validation_workflow_duration": null,
+      "validation_receipt_workflow_duration": null,
+      "authored_db_utilization": null,
+      "authored_db_connection_use_time": null,
+      "conductor_db_utilization": null,
+      "conductor_db_connection_use_time": null,
+      "dht_db_utilization": null,
+      "dht_db_connection_use_time": null
+    },
+    "host_metrics": {
+      "cpu": {
+        "usage_user": {
+          "count": 100,
+          "max": 53.89282103134561,
+          "mean": 42.06,
+          "min": 20.94662638469318,
+          "std": 8.63
+        },
+        "usage_system": {
+          "count": 100,
+          "max": 6.490872210952969,
+          "mean": 4.46,
+          "min": 1.925025329280558,
+          "std": 1.03
+        }
+      },
+      "memory": {
+        "active": {
+          "count": 22,
+          "max": 1032208384.0,
+          "mean": 957888139.64,
+          "min": 899674112.0,
+          "std": 39129550.4
+        },
+        "available": {
+          "count": 22,
+          "max": 15511756800.0,
+          "mean": 13991646301.09,
+          "min": 7313440768.0,
+          "std": 3144798090.77
+        },
+        "available_percent": {
+          "count": 22,
+          "max": 93.81177449800091,
+          "mean": 92.72,
+          "min": 88.73879649757914,
+          "std": 1.84
+        },
+        "free": {
+          "count": 22,
+          "max": 14818508800.0,
+          "mean": 13247073559.27,
+          "min": 6396973056.0,
+          "std": 3225179214.38
+        },
+        "inactive": {
+          "count": 22,
+          "max": 592072704.0,
+          "mean": 501690554.18,
+          "min": 456556544.0,
+          "std": 43553983.79
+        },
+        "swap_free": {
+          "count": 22,
+          "max": 8589910016.0,
+          "mean": 8482577687.27,
+          "min": 7999582208.0,
+          "std": 227686252.45
+        },
+        "swap_total": {
+          "count": 22,
+          "max": 8589910016.0,
+          "mean": 8482577687.27,
+          "min": 7999582208.0,
+          "std": 227686252.45
+        },
+        "total": {
+          "count": 22,
+          "max": 16534978560.0,
+          "mean": 15027080098.91,
+          "min": 8241537024.0,
+          "std": 3198735681.53
+        },
+        "used": {
+          "count": 22,
+          "max": 822435840.0,
+          "mean": 749217978.18,
+          "min": 660410368.0,
+          "std": 43509029.22
+        },
+        "used_percent": {
+          "count": 22,
+          "max": 8.182719097616712,
+          "mean": 5.27,
+          "min": 4.413975218362787,
+          "std": 1.34
+        }
+      },
+      "network": {
+        "bytes_recv": {
+          "docker0": {
+            "start": 0,
+            "end": 0,
+            "delta": 0,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 0.0
+          },
+          "enp1s0": {
+            "start": 0,
+            "end": 242467723,
+            "delta": 242467723,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 1310636.34
+          },
+          "enp2s0": {
+            "start": 142860459,
+            "end": 150904542,
+            "delta": 8044083,
+            "measurement_duration": {
+              "secs": 165,
+              "nanos": 0
+            },
+            "rate_per_second": 48752.02
+          },
+          "tailscale0": {
+            "start": 7763,
+            "end": 15394,
+            "delta": 7631,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 41.25
+          }
+        },
+        "bytes_sent": {
+          "docker0": {
+            "start": 0,
+            "end": 0,
+            "delta": 0,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 0.0
+          },
+          "enp1s0": {
+            "start": 0,
+            "end": 14301101,
+            "delta": 14301101,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 77303.25
+          },
+          "enp2s0": {
+            "start": 1627888,
+            "end": 22527810,
+            "delta": 20899922,
+            "measurement_duration": {
+              "secs": 165,
+              "nanos": 0
+            },
+            "rate_per_second": 126666.19
+          },
+          "tailscale0": {
+            "start": 5200,
+            "end": 24680,
+            "delta": 19480,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 105.3
+          }
+        },
+        "packets_recv": {
+          "docker0": {
+            "start": 0,
+            "end": 0,
+            "delta": 0,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 0.0
+          },
+          "enp1s0": {
+            "start": 0,
+            "end": 177933,
+            "delta": 177933,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 961.8
+          },
+          "enp2s0": {
+            "start": 103129,
+            "end": 114253,
+            "delta": 11124,
+            "measurement_duration": {
+              "secs": 165,
+              "nanos": 0
+            },
+            "rate_per_second": 67.42
+          },
+          "tailscale0": {
+            "start": 57,
+            "end": 119,
+            "delta": 62,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 0.34
+          }
+        },
+        "packets_sent": {
+          "docker0": {
+            "start": 0,
+            "end": 0,
+            "delta": 0,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 0.0
+          },
+          "enp1s0": {
+            "start": 0,
+            "end": 33892,
+            "delta": 33892,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 183.2
+          },
+          "enp2s0": {
+            "start": 13680,
+            "end": 29866,
+            "delta": 16186,
+            "measurement_duration": {
+              "secs": 165,
+              "nanos": 0
+            },
+            "rate_per_second": 98.1
+          },
+          "tailscale0": {
+            "start": 66,
+            "end": 232,
+            "delta": 166,
+            "measurement_duration": {
+              "secs": 185,
+              "nanos": 0
+            },
+            "rate_per_second": 0.9
+          }
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
### Summary

Closes #311 . Includes the CLI plus a sample template for the `dht_sync_lag` report.

To test the tool out: **UPDATED INSTRUCTIONS 2025-11-11**

1. In the project root, go `nix develop`
3. run `scenario-visualiser/generate.sh ../summariser/test_data/3_summary_outputs/dht_sync_lag-3a1e33ccf661bd873966c539d4d227e703e1496fb54bb999f7be30a3dd493e51.json > out.html`
4. open `out.html` in your browser

### TODO:

- [x] tests to ensure the tool works
- [x] All code changes are reflected in docs, including module-level docs

_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wind Tunnel Summary Visualiser: generates HTML report pages with interactive trend graphs, mean/std/max widgets, delta displays, and a DHT Sync Lag scenario view with comprehensive metric panels.

* **Documentation**
  * Added visualiser README, scenario template guidance, and TODO/planning notes.

* **Tests**
  * Added smoke-test script and test data to verify generated HTML output for scenarios.

* **Chores**
  * CI smoke-test entry added and .gitignore updated to ignore generated HTML.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->