### PR TITLE
ci: run the Summariser report generation once

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -228,6 +228,7 @@ jobs:
         run: nix develop --command ./nomad/scripts/ci_allocs.sh generate_run_summary alloc_ids.csv run_summary.jsonl
 
       - name: Run summariser
+        if: always()
         env:
           INFLUX_HOST: "https://ifdb.holochain.org"
           INFLUX_BUCKET: "windtunnel"


### PR DESCRIPTION
### Summary

Currently, we run the Summariser once for each scenario after it finishes. This means that not only do we rebuild the Summariser once for each scenario (see #330) but we also end up with multiple Summariser reports (one for each scenario). This does mean that if the Summariser fails on a single scenario then only that scenario fails to get a report instead of the whole job failing, but I don't think that this is the intended use of the Summariser.

This PR makes it so that the Summariser is run once at the end of the run and generates a single report for all scenarios that were run.

This is a suggestion so I'm happy to reject this PR and keep the existing behaviour but then we should probably have a job that combines the reports into a single one so it can be used by the visualiser tool being developed as part of #311.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow for consolidated run-summary generation and reporting: the wait job was renamed for clarity, a dedicated run-summary job now merges allocation IDs into a single source, summarisation always runs, and the summariser report is uploaded under a unified name for easier retrieval.
  * No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->