### PR TITLE
fix: validation_receipts scenario gets stuck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ lp-tool/lp-tool
 
 # Summary visualiser output
 *.html
+
+# Rust rover
+.idea/
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7429,10 +7429,11 @@ dependencies = [
 name = "validation_receipts"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "happ_builder",
  "holochain_types",
  "holochain_wind_tunnel_runner",
- "tokio",
+ "log",
 ]
 
 [[package]]

--- a/scenarios/validation_receipts/Cargo.toml
+++ b/scenarios/validation_receipts/Cargo.toml
@@ -6,7 +6,8 @@ build = "../scenario_build.rs"
 publish = false
 
 [dependencies]
-tokio = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
 
 holochain_types = { workspace = true }
 holochain_wind_tunnel_runner = { workspace = true }


### PR DESCRIPTION
### Summary

- Increased required nodes to 6
- Refactored the scenario logic.

closes #329

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI reduced to run only the validation_receipts scenario; required validation nodes increased from 2 to 6.

* **Improvements**
  * Receipt handling changed to per-action completion for finer-grained tracking.
  * Added per-action waiting with timing metrics and improved completion reporting.
  * Waiting behavior can be controlled via an environment variable for flexible test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->