### PR TITLE
ci: Cache summariser build

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -31,9 +31,41 @@ jobs:
       matrix:
         scenario-name:
           - first_call
+          - local_signals
+          - remote_call_rate
+          - remote_signals
+          - single_write_many_read
+          - write_query
+          - write_read
+          - write_validated
+          - zome_call_single_value
         include:
           - job-name: app_install_large
             scenario-name: app_install
+
+          - job-name: app_install_minimal
+            scenario-name: app_install
+
+          - scenario-name: dht_sync_lag
+            required-nodes: 2
+
+          - scenario-name: validation_receipts
+            required-nodes: 2
+
+          - scenario-name: write_get_agent_activity
+            required-nodes: 2
+
+          - scenario-name: write_validated_must_get_agent_activity
+            required-nodes: 2
+
+          - scenario-name: two_party_countersigning
+            required-nodes: 3
+
+          - scenario-name: zero_arc_create_data
+            required-nodes: 10
+
+          - scenario-name: zero_arc_create_and_read
+            required-nodes: 9
     env:
       RUN_ID: "${{ matrix.job-name || matrix.scenario-name }}_${{ github.run_id }}"
       JOB_NAME: "${{ matrix.job-name || matrix.scenario-name }}"


### PR DESCRIPTION
### Summary

closes #330.

Added ~~rust-cache~~ github cache to ci steps before running the summariser.

Unfortunately rust-cache can't be used because it requires to have rust in PATH, which we don't have. But caching `target` is enough

Here you can see the cache in action

- build: https://github.com/holochain/wind-tunnel/actions/runs/19635782055/job/56227264423
- cached: https://github.com/holochain/wind-tunnel/actions/runs/19636361490/job/56228795750

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow caching to speed up build/summary runs by storing and restoring dependency and build artifacts, reducing repeated work and shortening execution time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->