### PR TITLE
ci: Change Nomad scenario timeout to `(created_at - t_now) + duration + buffer`

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -228,7 +228,7 @@ jobs:
           # set timeout to duration + $buffer (seconds buffer) - (current_time - started_at)
           remaining=$(( duration - (current_time - started_at) ))
           export TIMEOUT=$(( $remaining + $buffer ))
-          export TIMEOUT=$(( TIMEOUT < 0 ? 600 : TIMEOUT )) # minimum timeout of 10 minutes
+          export TIMEOUT=$(( TIMEOUT < 0 ? $duration + $buffer : TIMEOUT )) # if timeout is negative; set to `duration + buffer`
           echo "Timeout for ${{ matrix.job_name }}: $TIMEOUT seconds (started_at: ${started_at}; duration: ${duration})"
           nix develop --command ./nomad/scripts/wait_for_jobs.sh ${{ matrix.job_name }} ${{ matrix.alloc_ids }}
 


### PR DESCRIPTION
Currently scenarios could get stuck for too long; use a meaningful timeout instead

closes #354

### Summary



### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD timeouts are now dynamic: computed from job duration and start time with a 120-second buffer and logged for visibility.
  * Job timing metadata (started_at, duration) is propagated across pipeline stages, persisted in matrices, and included in merged outputs and generated CSVs.
  * Run steps and downstream jobs emit explicit timeout and timing details for each job to aid tracing and diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->