### PR TITLE
Chore: refactor all handling of possibly missing values

### DIFF
--- a/summary-visualiser/templates/helpers/delta.html.tmpl
+++ b/summary-visualiser/templates/helpers/delta.html.tmpl
@@ -1,7 +1,7 @@
 <span class="delta">
     <span class="delta-start-end">
         <span class="delta-start">
-            {{- template "scalar" (dict "value" .start "unit" (or (index . "unit") nil)) -}}
+            {{- template "scalar" (dict "value" .start "unit" (index . "unit")) -}}
         </span>
         {{ if (lt .start .end) }}
             <span class="delta-dir delta-dir-up">&#x2B06;</span>
@@ -10,7 +10,7 @@
         {{ end }}
         {{ if (ne .start .end) }}
             <span class="delta-end">
-                {{- template "scalar" (dict "value" .end "unit" (or (index . "unit") nil)) -}}
+                {{- template "scalar" (dict "value" .end "unit" (index . "unit")) -}}
             </span>
         {{ end }}
     </span>
@@ -24,7 +24,7 @@
                     "unit" "%"
                 ) -}}
             </span>
-            <span class="delta-measurement-duration">over {{ .measurement_duration }}s ({{- template "scalar" (dict "value" .rate_per_second "unit" (or (index . "unit") nil)) -}}/s)</span>
+            <span class="delta-measurement-duration">over {{ .measurement_duration }}s ({{- template "scalar" (dict "value" .rate_per_second "unit" (index . "unit")) -}}/s)</span>
         </span>
     {{ end }}
 </span>

--- a/summary-visualiser/templates/helpers/mean_max.html.tmpl
+++ b/summary-visualiser/templates/helpers/mean_max.html.tmpl
@@ -1,10 +1,10 @@
 <div class="mean-max">
     <span class="mean-max-mean">
-        {{- template "scalar" (dict "value" .mean "unit" (or (index . "unit") nil)) -}}
+        {{- template "scalar" (dict "value" .mean "unit" (index . "unit")) -}}
     </span>
     {{ if (ne .mean .max) }}
         <span class="mean-max-max">(max
-            {{ template "scalar" (dict "value" .max "unit" (or (index . "unit") nil)) -}})
+            {{ template "scalar" (dict "value" .max "unit" (index . "unit")) -}})
         </span>
     {{ end }}
 </div>

--- a/summary-visualiser/templates/helpers/mean_std.html.tmpl
+++ b/summary-visualiser/templates/helpers/mean_std.html.tmpl
@@ -1,8 +1,8 @@
 <div class="mean-std">
     <span class="mean-std-mean">
-        {{- template "scalar" (dict "value" .mean "unit" (or (index . "unit") nil)) -}}
+        {{- template "scalar" (dict "value" .mean "unit" (index . "unit")) -}}
     </span>
     <span class="mean-std-std">(SD =
-        {{ template "scalar" (dict "value" .std "unit" (or (index . "unit") nil)) -}})
+        {{ template "scalar" (dict "value" .std "unit" (index . "unit")) -}})
     </span>
 </div>

--- a/summary-visualiser/templates/helpers/min_max_mean_std.html.tmpl
+++ b/summary-visualiser/templates/helpers/min_max_mean_std.html.tmpl
@@ -1,22 +1,21 @@
-{{- $unit := default nil (index . "unit") -}}
 <span class="min-max-mean-std">
     {{ template "scalar" (dict
         "class" "min"
         "value" .min
-        "unit" $unit
+        "unit" (index . "unit")
     ) }}
     {{ $min_mean_symbol := test.Ternary "lt" "le" (lt .min .mean) }}
     <span class="divider divider-{{ $min_mean_symbol }}">&{{ $min_mean_symbol }};</span>
     {{ template "mean_std" (dict
         "mean" .mean
         "std" .std
-        "unit" $unit
+        "unit" (index . "unit")
     )}}
     {{ $mean_max_symbol := test.Ternary "lt" "le" (lt .mean .max) }}
     <span class="divider divider-{{ $mean_max_symbol }}">&{{ $mean_max_symbol }};</span>
     {{ template "scalar" (dict
         "class" "max"
         "value" .max
-        "unit" $unit
+        "unit" (index . "unit")
     ) }}
 </span>

--- a/summary-visualiser/templates/helpers/trend_graph.html.tmpl
+++ b/summary-visualiser/templates/helpers/trend_graph.html.tmpl
@@ -4,7 +4,7 @@
         <svg id="trend-svg-{{ $svg_id }}"></svg>
     </div>
 
-    <script>createTrendGraph("trend-svg-{{ $svg_id }}", [{{ conv.Join .data ", " }}], {{ .mean }}, "{{ .window_duration }}", "{{ or (index . "unit") "" }}");</script>
+    <script>createTrendGraph("trend-svg-{{ $svg_id }}", [{{ conv.Join .data ", " }}], {{ .mean }}, "{{ .window_duration }}", "{{ default "" (index . "unit") }}");</script>
 {{ else }}
     <div class="no-trend-graph">No trend data available.</div>
 {{ end }}


### PR DESCRIPTION
### Summary

Gomplate distinguishes between a non-value and an empty value. If you try to render a non-value (e.g., using `index . "foo"` on a struct that has no `foo` field) it outputs the string `<no data>` or something like that, so you have to guard against this condition.

Previously I used a mess of different styles before settling on Gomplate's `default` function with an empty string for the empty value. This PR standardises that across the codebase, and removes some redundant checks.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized unit handling across summary visualiser templates to ensure more consistent unit display.

* **Bug Fix**
  * Tightened unit resolution so units are treated as required where appropriate, reducing inconsistent or missing unit output.

* **Behavior**
  * Preserved an explicit empty-string fallback for trend graphs to avoid unexpected placeholders when no unit is provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->