### PR TITLE
Fix: Namespace all helpers defined locally in scenario templates

### DIFF
--- a/summary-visualiser/templates/scenarios/dht_sync_lag.html.tmpl
+++ b/summary-visualiser/templates/scenarios/dht_sync_lag.html.tmpl
@@ -1,7 +1,7 @@
 {{/* The description is a 'partial' that gets passed to the `scenario_summary` template.
 We could pass it as a string literal instead, but this is nicer
 because your code editor's syntax highlighter can make it look more legible. */}}
-{{- define "description" }}
+{{- define "dht_sync_lag_description" }}
 <p>Measure lag time between an agent publishing data and other peers being able to see it. This scenario has two roles:</p>
 
 <ul>
@@ -18,7 +18,7 @@ into a content block that gets passed to the scenario_metric template call.
 In most cases we just call `tmpl.Exec` with a metric,
 but in this case we need to loop over an array of function calls,
 and there's no function equivalent to `range` like there is for `template`/`tmpl.Exec`. */}}
-{{ define "wasm_usage_by_fn" }}
+{{ define "dht_sync_lag_wasm_usage_by_fn" }}
     {{ range $key, $data := . }}
         {{ template "scenario_metric_content_item" (dict
             "name" $key
@@ -33,7 +33,7 @@ and there's no function equivalent to `range` like there is for `template`/`tmpl
 {{ end }}
 
 {{/* Same situation here, for the authored DB utilisation. */}}
-{{ define "authored_db_utilization" }}
+{{ define "dht_sync_lag_authored_db_utilization" }}
     {{ range $name, $value := . }}
         {{ template "scenario_metric_content_item" (dict
             "name" (print "Utilisation for " $name)
@@ -47,7 +47,7 @@ and there's no function equivalent to `range` like there is for `template`/`tmpl
 {{ end }}
 
 {{/* And for countersigning agents. */}}
-{{ define "countersigning_workflow_duration" }}
+{{ define "dht_sync_lag_countersigning_workflow_duration" }}
     {{ range $agent, $value := .}}
         {{ template "scenario_metric_content_item" (dict
             "name" $agent
@@ -70,7 +70,7 @@ and there's no function equivalent to `range` like there is for `template`/`tmpl
 
 {{ template "scenario_summary" (dict
     "title" "DHT Sync Lag"
-    "description" (tmpl.Exec "description")
+    "description" (tmpl.Exec "dht_sync_lag_description")
     "data" .run_summary
 ) }}
 
@@ -174,7 +174,7 @@ and there's no function equivalent to `range` like there is for `template`/`tmpl
                             "rate_per_second" .wasm_usage_total.rate_per_second
                         ))
                     ))))
-                    (default "" (and .wasm_usage_by_fn (tmpl.Exec "wasm_usage_by_fn" .wasm_usage_by_fn)))
+                    (default "" (and .wasm_usage_by_fn (tmpl.Exec "dht_sync_lag_wasm_usage_by_fn" .wasm_usage_by_fn)))
                 )
             ) }}
         {{ end }}
@@ -242,7 +242,7 @@ and there's no function equivalent to `range` like there is for `template`/`tmpl
         {{ with .countersigning_workflow_duration }}
             {{ template "scenario_metric" (dict
                 "name" "Countersigning workflow duration"
-                "content" (tmpl.Exec "countersigning_workflow_duration" .)
+                "content" (tmpl.Exec "dht_sync_lag_countersigning_workflow_duration" .)
             ) }}
         {{ end }}
 
@@ -311,7 +311,7 @@ and there's no function equivalent to `range` like there is for `template`/`tmpl
                 "name" "Authored DB"
                 "description" "The utilization of connections in the authored database connection pool."
                 "content" (print
-                    (default "" (and .authored_db_utilization (tmpl.Exec "authored_db_utilization" .authored_db_utilization)))
+                    (default "" (and .authored_db_utilization (tmpl.Exec "dht_sync_lag_authored_db_utilization" .authored_db_utilization)))
                     (default "" (and .authored_db_connection_use_time (tmpl.Exec "db_connection_use_time" .authored_db_connection_use_time)))
                 )
             ) }}

--- a/summary-visualiser/templates/scenarios/remote_call_rate.html.tmpl
+++ b/summary-visualiser/templates/scenarios/remote_call_rate.html.tmpl
@@ -1,4 +1,4 @@
-{{- define "description" }}
+{{- define "remote_call_rate_description" }}
 <p>Test the throughput of <code>remote_call</code> operations. Each agent in this scenario waits for a certain number of peers to be available or for up to two minutes, whichever happens first, before starting its behaviour.</p>
 {{ end -}}
 
@@ -8,7 +8,7 @@ Set up a helper template that does the whole thing. */}}
 
 {{/* The loop to display mean, std, and trend graph for each agent.
 This is stripped out into its own helper so we can enjoy nice syntax highlighting. */}}
-{{- define "per_agent" }}
+{{- define "remote_call_rate_timing_per_agent" }}
     {{ range .data }}
         {{ template "scenario_metric_content_item" (dict
             "name" (tmpl.Exec "composite_key" .key)
@@ -31,7 +31,7 @@ This is stripped out into its own helper so we can enjoy nice syntax highlightin
 {{ end -}}
 
 {{/* And now the body of the metric helper. */}}
-{{ define "metric" }}
+{{ define "remote_call_rate_timing_metric" }}
     {{ template "scenario_metric" (dict
         "name" .name
         "description" .description
@@ -45,7 +45,7 @@ This is stripped out into its own helper so we can enjoy nice syntax highlightin
                     "unit" "s"
                 ))
             ))
-            (tmpl.Exec "per_agent" (dict
+            (tmpl.Exec "remote_call_rate_timing_per_agent" (dict
                 "data" .data.timings
                 "unit" "s"
             ))
@@ -55,18 +55,18 @@ This is stripped out into its own helper so we can enjoy nice syntax highlightin
 
 {{ template "scenario_summary" (dict
     "title" "Remote Call Rate"
-    "description" (tmpl.Exec "description")
+    "description" (tmpl.Exec "remote_call_rate_description")
     "data" .run_summary
 ) }}
 
 <div class="scenario-metrics">
-    {{ template "metric" (dict
+    {{ template "remote_call_rate_timing_metric" (dict
         "name" "Dispatch timing"
         "description" "The time between sending a remote call and the remote handler being invoked."
         "data" .scenario_metrics.dispatch_timing
     ) }}
 
-    {{ template "metric" (dict
+    {{ template "remote_call_rate_timing_metric" (dict
         "name" "Round-trip timing"
         "description" "The total elapsed time to get a response to the client."
         "data" .scenario_metrics.round_trip_timing

--- a/summary-visualiser/templates/scenarios/validation_receipts.html.tmpl
+++ b/summary-visualiser/templates/scenarios/validation_receipts.html.tmpl
@@ -1,4 +1,4 @@
-{{- define "description" }}
+{{- define "validation_receipts_description" }}
 <p>Creates an entry, wait for required validation receipts, then repeat. Records the amount of time it took to accumulate the required number of receipts for all DHT operations. This is measured to the nearest 20ms so that we don't keep the agent too busy checking for receipts.</p>
 
 <p>Each agent in this scenario waits for a certain number of peers to be available or for up to two minutes, whichever happens first, before starting its behaviour.</p>
@@ -6,7 +6,7 @@
 <p>By default, this scenario will wait for a complete set of validation receipts before committing the next record. If the <code>NO_VALIDATION_COMPLETE</code> environment variable is set, it will instead publish new records on every round, building up an ever-growing list of action hashes to check on.</p>
 {{ end -}}
 
-{{- define "timing_per_agent_and_op" }}
+{{- define "validation_receipts_timing_per_agent_and_op" }}
     {{ range . }}
         {{ template "scenario_metric_content_item" (dict
             "name" (tmpl.Exec "composite_key" .key)
@@ -27,7 +27,7 @@
     {{ end }}
 {{ end -}}
 
-{{- define "rate_per_agent_and_op" }}
+{{- define "validation_receipts_rate_per_agent_and_op" }}
     {{ range . }}
         {{ template "scenario_metric_content_item" (dict
             "name" (tmpl.Exec "composite_key" .key)
@@ -49,7 +49,7 @@
 
 {{ template "scenario_summary" (dict
     "title" "Validation Receipts"
-    "description" (tmpl.Exec "description")
+    "description" (tmpl.Exec "validation_receipts_description")
     "data" .run_summary
 ) }}
 
@@ -68,7 +68,7 @@
                         "unit" "s"
                     ))
                 ))
-                (tmpl.Exec "timing_per_agent_and_op" .timings)
+                (tmpl.Exec "validation_receipts_timing_per_agent_and_op" .timings)
             )
         ) }}
     {{ end }}
@@ -86,7 +86,7 @@
                         "unit" "/s"
                     ))
                 ))
-                (tmpl.Exec "rate_per_agent_and_op" .rates)
+                (tmpl.Exec "validation_receipts_rate_per_agent_and_op" .rates)
             )
         ) }}
     {{ end }}

--- a/summary-visualiser/templates/scenarios/zero_arc_create_data.html.tmpl
+++ b/summary-visualiser/templates/scenarios/zero_arc_create_data.html.tmpl
@@ -1,4 +1,4 @@
-{{- define "description" }}
+{{- define "zero_arc_create_data_description" }}
 A zero-arc/full-arc mixed scenario where zero-arc nodes create data and full-arc nodes read the data. The scenario has two roles:
 
 <ul>
@@ -7,7 +7,7 @@ A zero-arc/full-arc mixed scenario where zero-arc nodes create data and full-arc
 </ul>
 {{ end -}}
 
-{{ define "sync_lag_timing_per_agent" }}
+{{ define "zero_arc_create_data_sync_lag_timing_per_agent" }}
     {{ range . }}
         {{ template "scenario_metric_content_item" (dict
             "name" (tmpl.Exec "composite_key" .key)
@@ -28,7 +28,7 @@ A zero-arc/full-arc mixed scenario where zero-arc nodes create data and full-arc
     {{ end }}
 {{ end }}
 
-{{ define "sync_lag_rate_per_agent" }}
+{{ define "zero_arc_create_data_sync_lag_rate_per_agent" }}
     {{ range . }}
         {{ template "scenario_metric_content_item" (dict
             "name" (tmpl.Exec "composite_key" .key)
@@ -48,7 +48,7 @@ A zero-arc/full-arc mixed scenario where zero-arc nodes create data and full-arc
     {{ end }}
 {{ end }}
 
-{{ define "open_connections" }}
+{{ define "zero_arc_create_data_open_connections" }}
     {{ range . }}
         {{ $key := (index .key 0) }}
         {{ template "scenario_metric_content_item" (dict
@@ -65,7 +65,7 @@ A zero-arc/full-arc mixed scenario where zero-arc nodes create data and full-arc
 
 {{ template "scenario_summary" (dict
     "title" "Zero-Arc Create Data"
-    "description" (tmpl.Exec "description")
+    "description" (tmpl.Exec "zero_arc_create_data_description")
     "data" .run_summary
 ) }}
 
@@ -104,7 +104,7 @@ A zero-arc/full-arc mixed scenario where zero-arc nodes create data and full-arc
                             "unit" "s"
                         ))
                     ))
-                    (tmpl.Exec "sync_lag_timing_per_agent" .timings)
+                    (tmpl.Exec "zero_arc_create_data_sync_lag_timing_per_agent" .timings)
                 )
             ) }}
         {{ end }}
@@ -122,7 +122,7 @@ A zero-arc/full-arc mixed scenario where zero-arc nodes create data and full-arc
                             "unit" "/s"
                         ))
                     ))
-                    (tmpl.Exec "sync_lag_rate_per_agent" .rates)
+                    (tmpl.Exec "zero_arc_create_data_sync_lag_rate_per_agent" .rates)
                 )
             ) }}
         {{ end }}
@@ -131,7 +131,7 @@ A zero-arc/full-arc mixed scenario where zero-arc nodes create data and full-arc
             {{ template "scenario_metric" (dict
                 "name" "Open connections"
                 "description" "The number of currently open connections to other conductors."
-                "content" (tmpl.Exec "open_connections" .)
+                "content" (tmpl.Exec "zero_arc_create_data_open_connections" .)
             ) }}
         {{ end }}
 


### PR DESCRIPTION
### Summary

At first I noticed this issue because the description was the same for all scenarios when running on a JSON with multiple scenarios. Turns out inline helpers defined with `{{ define }}` aren't scoped to the file. I namespaced all other locally defined helpers just to be on the safe side.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
