### PR TITLE
ci: Disable validation_receipts scenario

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -49,9 +49,6 @@ jobs:
           - scenario-name: dht_sync_lag
             required-nodes: 10
 
-          - scenario-name: validation_receipts
-            required-nodes: 2
-
           - scenario-name: write_get_agent_activity
             required-nodes: 2
 


### PR DESCRIPTION
### Summary

I've temporarily disabled the `validation_receipts` scenario because as shown in this PR <https://github.com/holochain/wind-tunnel/pull/337> the receipts validation flow may be bugged.

I'm opening a PR showcasing the issue on holochain to verify whether this bug exists and how can we fix it eventually.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD pipeline to remove a specific test scenario and its explicit resource allocation, reducing the number of executed scenarios and streamlining test execution workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->