### PR TITLE
chore: reverse styling of assigned behaviour keys/values

### DIFF
--- a/summary-visualiser/assets/wind_tunnel.css
+++ b/summary-visualiser/assets/wind_tunnel.css
@@ -56,14 +56,14 @@ This CSS needs the following variables to be defined:
     font-weight: bold;
 }
 
-.scenario-summary-kv {
+.scenario-summary-behaviours {
     margin-top: 0;
     margin-bottom: 0;
     padding-left: 0;
     list-style: none;
 }
 
-.scenario-summary-kv-key {
+.scenario-summary-behaviour-agent-count {
     font-weight: normal;
     color: var(--subtle);
 }

--- a/summary-visualiser/templates/helpers/scenario_summary.html.tmpl
+++ b/summary-visualiser/templates/helpers/scenario_summary.html.tmpl
@@ -33,17 +33,17 @@
         <div class="scenario-summary-details-line">
             <div class="scenario-summary-details-label">Behaviours</div>
             <div class="scenario-summary-details-value">
-                <ul class="scenario-summary-kv scenario-summary-assigned-behaviours">
+                <ul class="scenario-summary-behaviours">
                     {{ range $behaviour, $count := .data.assigned_behaviours }}
                         <li>
-                            <span class="scenario-summary-kv-key">
+                            <span class="scenario-summary-behaviour-name">
                                 {{- if $behaviour -}}
                                     <code>{{ $behaviour }}</code>
                                 {{- else -}}
                                     Default
                                 {{- end -}}
-                            :</span>
-                            {{ $count }} agent{{ if (ne $count 1) }}s{{ end }}
+                            </span>
+                            <span class="scenario-summary-behaviour-agent-count">({{ $count }} agent{{ if (ne $count 1) }}s{{ end }})</span>
                         </li>
                     {{ end }}
                 </ul>


### PR DESCRIPTION
### Summary

The behaviour name is more important than the number of agents assigned to the behaviour. Follow-up from this comment: https://github.com/holochain/wind-tunnel/pull/371#pullrequestreview-3546166584

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
