### PR TITLE
fix: change holochain binary url to specific tag

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  HOLOCHAIN_BIN_URL: "${{ inputs.holochain_bin_url || 'https://github.com/holochain/holochain/releases/latest/download/holochain-go-pion-unstable-x86_64-unknown-linux-gnu' }}"
+  HOLOCHAIN_BIN_URL: "${{ inputs.holochain_bin_url || 'https://github.com/holochain/holochain/releases/download/holochain-0.5.6/holochain-go-pion-unstable-x86_64-unknown-linux-gnu' }}"
 
 jobs:
   run-scenarios:

--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ nomad job run -address=http://localhost:4646 -var scenario_url=result/bin/app_in
 Or to download and use a different Holochain binary to start the conductors:
 
 ```bash
-nomad job run -address=http://localhost:4646 -var scenario_url=result/bin/app_install -var reporter=in-memory -var holochain_bin_url=https://github.com/holochain/holochain/releases/latest/download/holochain-x86_64-unknown-linux-gnu nomad/jobs/app_install_minimal.nomad.hcl
+nomad job run -address=http://localhost:4646 -var scenario_url=result/bin/app_install -var reporter=in-memory -var holochain_bin_url=https://github.com/holochain/holochain/releases/download/holochain-0.5.6/holochain-x86_64-unknown-linux-gnu nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
 Then, navigate to <http://localhost:4646/ui/jobs> where you should see your job listed, after clicking on
@@ -662,7 +662,7 @@ At this point you have to generate the Nomad job for the scenario you want to ru
 Now that the scenario zip file is publicly available you can run the scenario with the following:
 
 ```bash
-nomad job run -var scenario_url=http://{some-url} -var holochain_bin_url=https://github.com/holochain/holochain/releases/latest/download/holochain-x86_64-unknown-linux-gnu nomad/jobs/app_install_minimal.nomad.hcl
+nomad job run -var scenario_url=http://{some-url} -var holochain_bin_url=https://github.com/holochain/holochain/releases/download/holochain-0.5.6/holochain-x86_64-unknown-linux-gnu nomad/jobs/app_install_minimal.nomad.hcl
 ```
 
 - `-var scenario_url=...` provides the URL to the scenario zip file that you uploaded in the previous step.


### PR DESCRIPTION
### Summary

Have the holochain binary url point to a specific release instead of latest to prevent nomad from using a 0.6.0 holochain binary.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration and documentation to use a pinned version of holochain (0.5.6) instead of fetching the latest build by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->