### PR TITLE
chore: separate main WT tests from summary visualiser ones

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,11 +26,13 @@ jobs:
           filters: |
             wind_tunnel:
               - '!summary-visualiser/**'
+              - '!.github/workflows/test.yaml'
             summary_visualiser:
               - 'summary-visualiser/**'
             # See if this file has changed -- if so, it should trigger both CI jobs.
             test_workflow:
               - '.github/workflows/test.yaml'
+          predicate-quantifier: 'every'
 
   test_wind_tunnel:
     if: needs.check_paths.outputs.wind_tunnel_changed == 'true' || needs.check_paths.outputs.test_workflow_changed == 'true' || github.event_name == 'merge_group'


### PR DESCRIPTION
### Summary

This change has not been asked for, and I used Cursor to help me refactor the `test` workflow, so I'm quite okay with this PR being shot down.

I'm experiencing a lot of dead time waiting for CI to pass for small changes and small PRs. As far as I can tell, this is wasted CI work, because:

* my changes almost exclusively touch files in the `summary-visualiser` folder and use test data from that same folder
* the summary visualiser is downstream of anything else being tested in that job

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked CI to split testing into multiple parallel jobs with path-aware filtering to run only relevant checks.
  * Added aggregated status reporting that shows overall test results while permitting allowed skips for some parallel jobs.
  * Made artifact archiving and pipeline pass gating conditional on relevant test outcomes to improve efficiency and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->