### PR TITLE
fix: filter links by agent in write validated must_get_agent_activity zome

### DIFF
--- a/zomes/validated_must_get_agent_activity/coordinator/src/lib.rs
+++ b/zomes/validated_must_get_agent_activity/coordinator/src/lib.rs
@@ -52,11 +52,15 @@ fn create_sample_entries_batch(count: u64) -> ExternResult<()> {
 #[hdk_extern]
 fn create_validated_sample_entry(agent: AgentPubKey) -> ExternResult<usize> {
     // Get last created action hash
-    let mut links: Vec<Link> = get_links(
+    let links: Vec<Link> = get_links(
         GetLinksInputBuilder::try_new(chain_head_anchor()?, LinkTypes::LatestAction)?.build(),
     )?;
-    links.sort_by_key(|l| l.timestamp);
-    let chain_head_link: Link = links
+    let mut links_from_write_agent = links
+        .into_iter()
+        .filter(|l| l.author == agent)
+        .collect::<Vec<Link>>();
+    links_from_write_agent.sort_by_key(|l| l.timestamp);
+    let chain_head_link: Link = links_from_write_agent
         .last()
         .ok_or_else(|| {
             wasm_error!(WasmErrorInner::Guest(String::from(


### PR DESCRIPTION
### Summary

The logic of the `create_validated_sample_entry` zome function used by the `write_validated_must_get_agent_activity` scenario was missing a filtering step to filter by agent. Without it, the scenario only works properly in case of a single write peer.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined agent activity validation to ensure records authored by the specified agent are properly filtered before further processing.
  * Ordered the agent-specific activity by timestamp and used the most recent entry to determine chain state, improving accuracy of chain head selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->