### PR TITLE
fix: eliminate race condition in holochain_binary tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5543,6 +5543,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5623,6 +5632,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -5801,6 +5816,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -7496,6 +7536,7 @@ dependencies = [
  "log",
  "nanoid",
  "serde_json",
+ "serial_test",
  "sysinfo 0.35.2",
  "tempfile",
  "tokio",

--- a/framework/runner/Cargo.toml
+++ b/framework/runner/Cargo.toml
@@ -28,6 +28,7 @@ wind_tunnel_instruments = { workspace = true }
 wind_tunnel_summary_model = { workspace = true }
 
 [dev-dependencies]
+serial_test = "3.2"
 tempfile = { workspace = true }
 
 [lints]

--- a/framework/runner/src/holochain_binary.rs
+++ b/framework/runner/src/holochain_binary.rs
@@ -74,11 +74,13 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt as _;
 
+    use serial_test::serial;
     use tempfile::{NamedTempFile, TempDir};
 
     use super::*;
 
     #[test]
+    #[serial]
     fn test_should_not_get_holochain_path_if_not_exist() {
         env::set_var(WT_HOLOCHAIN_PATH_ENV, "/non/existent/path/to/holochain");
         let result = holochain_path();
@@ -86,6 +88,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_should_get_holochain_path_from_env() {
         let temp = NamedTempFile::new().expect("failed to create temp file");
         let test_path = temp.path().to_str().expect("failed to get temp file path");
@@ -96,6 +99,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial]
     fn test_should_get_default_holochain_path() {
         let temp = TempDir::new().expect("failed to create temp file");
         // create holochain file in temp dir
@@ -119,6 +123,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_should_not_get_default_holochain_path() {
         // unset PATH
         env::remove_var("PATH");


### PR DESCRIPTION
### Summary

The test `test_should_get_default_holochain_path` was flaky due to race conditions caused by parallel test execution modifying shared global environment variables (WT_HOLOCHAIN_PATH_ENV and PATH).

When tests ran in parallel, one test could modify environment variables while another was executing, causing sporadic failures with the error: "Path to Holochain binary overwritten with
'WT_HOLOCHAIN_PATH=/non/existent/path/to/holochain' but that path doesn't exist"

Solution:
- Added `serial_test` crate as a dev dependency
- Applied `#[serial]` attribute to all four tests that modify environment variables, ensuring they run sequentially

Tests verified to pass consistently across 20 consecutive runs.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test suite configured to run tests serially to avoid parallel interference and improve reliability.
  * Added a development testing dependency to enable serialized test execution.
  * No changes to production behavior or public APIs; only test execution ordering was adjusted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->