### PR TITLE
feat: upload summary json to hetzner bucket

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -283,15 +283,19 @@ jobs:
           RUST_LOG: debug
         run: nix develop --command cargo run --release --bin holochain-summariser
 
+      - name: Generate summary id for artifacts
+        id: generate-summary-id
+        run: |
+          SUMMARY_ID="$(date +%Y%m%d%H%M%S).${{ inputs.commit_hash || github.sha }}"
+          echo "summary_id=$SUMMARY_ID" >> "$GITHUB_OUTPUT"
+
       - name: Generate summary visualiser
-        env:
-          HASH: "${{ inputs.commit_hash || github.sha }}"
         run: |
           # The summary visualiser can only take one file at a time,
           # but only one summariser report JSON file is fed to it in a run.
           # The wildcard here is because we don't know the name of the file.
           mkdir -p ./nomad-summary-visualiser
-          output_file="./nomad-summary-visualiser/run.$(date +%Y%m%d%H%M%S).${{ env.HASH }}.html"
+          output_file="./nomad-summary-visualiser/run.${{ steps.generate-summary-id.outputs.summary_id }}.html"
           nix run .#generate-summary-visualiser ./summariser-report-*.json "$output_file"
 
       - name: Push run.html to GitHub Pages
@@ -303,8 +307,15 @@ jobs:
           keep_files: true
           enable_jekyll: true
 
-      - name: Upload run summary
-        uses: actions/upload-artifact@v6
-        with:
-          name: summariser-report
-          path: ./summariser-report-*.json
+      - name: Upload run summary to bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_ACCESS }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET }}
+          AWS_DEFAULT_REGION: fsn1
+          AWS_ENDPOINT_URL: https://fsn1.your-objectstorage.com
+          S3_BUCKET_NAME: wind-tunnel-artifacts
+        run: |-
+          OUT_PATH="${S3_BUCKET_NAME}/summariser-reports/${{ steps.generate-summary-id.outputs.summary_id }}.json"
+          nix run .#awscli-s3-cp summariser-report-*.json "s3://${OUT_PATH}"
+
+          echo "Uploaded run summary to ${AWS_ENDPOINT_URL}/${OUT_PATH}" >> "$GITHUB_STEP_SUMMARY"

--- a/flake.nix
+++ b/flake.nix
@@ -420,6 +420,18 @@
               ./summary-visualiser/generate.sh "$1" > "$2"
             '';
           };
+          awscli-s3-cp = pkgs.writeShellApplication {
+            name = "awscli-s3-cp";
+            runtimeInputs = [
+              pkgs.awscli2
+            ];
+            text = ''
+              set -euo pipefail
+
+              # shellcheck disable=SC1091
+              aws s3 cp "$1" "$2"
+            '';
+          };
           rust-unit-tests = pkgs.writeShellApplication {
             name = "rust-unit-tests";
             runtimeInputs = [


### PR DESCRIPTION
### Summary
Resolves #358  

Currently the bucket content private. We could make it public for reading, if desired. Otherwise you need the tokens or to be logged into hetzner to view bucket contents.

The summary visualizer doesn't actually need access to the bucket since it runs on the local summary json and then publishes the output html to github pages.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now generates stable summary IDs and uses them consistently across workflow steps.
  * Run summaries are uploaded to cloud object storage (bucket-backed); upload locations are recorded in the workflow summary.
  * Added a developer utility to simplify copying artifacts to S3-compatible object storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->