### PR TITLE
feat: run nomad scenario on all node pools

### DIFF
--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -33,6 +33,7 @@ variable "run_id" {
 job "{{ (ds "vars").scenario_name }}" {
   type        = "batch"
   all_at_once = true // Try to run all groups at once
+  node_pool = "all" // Run on all node pools
 
   constraint {
     distinct_hosts = true // Don't run multiple instances on the same client at once


### PR DESCRIPTION
### Summary
Counterpart to https://github.com/holochain/wind-tunnel-runner/pull/43

In the future we may want to split up the `nomad.yaml` github action to run smoke tests only on the "default" pool (which is used by our managed runners that installed the iso directly) while running general tests on "all" pools.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Job scheduling updated to allow execution across all node pools, expanding where batch jobs can run and improving scheduling flexibility and resource utilization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->