### PR TITLE
ci: Increase time buffer when timing out an allocation

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -232,8 +232,8 @@ jobs:
           started_at=${{ matrix.started_at }}
           duration=${{ matrix.duration }}
           current_time=$(date +%s)
-          buffer=120
-          # set timeout to duration + $buffer (seconds buffer) - (current_time - started_at)
+          buffer=300
+          # set timeout to $duration + $buffer (seconds $buffer) - ($current_time - $started_at)
           remaining=$(( duration - (current_time - started_at) ))
           export TIMEOUT=$(( $remaining + $buffer ))
           export TIMEOUT=$(( TIMEOUT < 0 ? $duration + $buffer : TIMEOUT )) # if timeout is negative; set to `duration + buffer`


### PR DESCRIPTION
### Summary

This run failed https://github.com/holochain/wind-tunnel/actions/runs/20273496523/job/58236949525. Looking at the timings, the scenario is meant to run for 5 minutes and a buffer of 2 minutes was given. However, the scenario actually took 7 minutes and 48 seconds to complete. 

The point of this timeout was just to make the timeout dynamic based on the scenario to be run, so we're not waiting 30 minutes regardless of how long the scenario is actually configured to run for. It appears that 2 minutes isn't enough buffer time for the artifact download and metrics upload to finish.

I think it's actually be smart to look more closely at the job status from Nomad. So we apply the timeout only if the scenario itself runs unreasonably long. The metrics upload steps and artifact download need to be able to take as long as required. That's a more involved change to figure out querying those states though.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout buffer for Nomad job calculations from 120 to 300 seconds, providing additional time before job timeout occurs.
  * Updated workflow documentation to clarify timeout calculation references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->