### PR TITLE
refactor: remove countersigning scenario from CI workflows

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -57,9 +57,6 @@ jobs:
           - scenario-name: write_validated_must_get_agent_activity
             required-nodes: 2
 
-          - scenario-name: two_party_countersigning
-            required-nodes: 3
-
           - scenario-name: zero_arc_create_data
             required-nodes: 10
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -183,14 +183,6 @@ jobs:
           echo
           df -h
 
-      - name: Smoke test - two_party_countersigning
-        run: |
-          MIN_AGENTS=2 nix run .#rust-smoke-test -- --package two_party_countersigning -- --agents 2 --behaviour initiate:1 --behaviour participate:1 --duration 30
-
-          echo "==> Available space after step"
-          echo
-          df -h
-
       - name: Smoke test - validation_receipts
         run: |
           set -x


### PR DESCRIPTION
### Summary

Removes the countersigning scenario from `nomad.yaml` and `test.yaml` to not have to bother about flaky behaviour for the time being.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed testing for the "two_party_countersigning" scenario from CI workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->