### PR TITLE
fix: run run-summary job even if individual scenarios fail

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -241,6 +241,7 @@ jobs:
     name: Generate a summary of all scenarios
     runs-on: [self-hosted, wind-tunnel]
     needs: wait-for-jobs
+    if: always()
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
### Summary
Run run-summary job even if some scenarios fail.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow configuration to ensure consistent summary generation regardless of prior step outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->