### PR TITLE
fix: create telegraf metrics output dir if not found, to avoid the task failing and restarting 2m later

### DIFF
--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -77,8 +77,8 @@ job "{{ (ds "vars").scenario_name }}" {
           }
 
           config {
-            command = "telegraf"
-            args    = []
+            command = "sh"
+            args    = ["-c", "mkdir -p ${WT_METRICS_DIR} && telegraf --config ${NOMAD_TASK_DIR}/telegraf.host.conf"]
           }
         }
       }


### PR DESCRIPTION
### Summary
Resolves #375 

I ran the Nomad CI workflow for 1 scenario and check its logs to confirm that `report_host_metrics` started successfully on the first try. Previously it would fail to start on the first try consistently.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics startup reliability by ensuring required metrics storage is created before the monitoring agent starts, reducing failed or missed metric collections during initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->