### PR TITLE
feat: do not retry jobs or tasks when a task fails, instead fail the job immediately

### DIFF
--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -49,9 +49,8 @@ job "{{ (ds "vars").scenario_name }}" {
 
     content {
       restart {
-        interval         = "30m"
-        attempts         = 5
-        delay            = "120s"
+        attempts = 0
+        mode = "fail"
       }
 
       dynamic "task" {


### PR DESCRIPTION
### Summary
Depends on #423 

With #423, we should not expect to have failing tasks regularly.

Currently if a task fails, it waits 2 minutes and then retries, up to 5 times. The scenario may have completed by then, so that node's data would no longer be valuable.

This is a proposal to just fail the job if a task fails, rather than retrying. I think its better to complete the scenario with 1 less node then keep the node occupied longer than necessary, and then upload data that is not relevant.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated restart policy to use a mode-based "fail" behavior with zero retry attempts; removed explicit interval and delay retry settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->