### PR TITLE
refactor: upload scenario bin to bucket, delete after scenario completes

### DIFF
--- a/.github/workflows/nomad-canonical.yaml
+++ b/.github/workflows/nomad-canonical.yaml
@@ -17,6 +17,7 @@ jobs:
       INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
       HETZNER_HOLOCHAIN_INFRA_BUCKETS_ACCESS: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_ACCESS }}
       HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET }}
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       holochain-bin-url: https://github.com/holochain/holochain/releases/download/holochain-0.5.6/holochain-go-pion-unstable-x86_64-unknown-linux-gnu
       nomad-job-variant-directory: "nomad/job-variants/canonical"

--- a/.github/workflows/nomad-common.yaml
+++ b/.github/workflows/nomad-common.yaml
@@ -29,9 +29,11 @@ on:
       INFLUX_TOKEN:
         required: true
       HETZNER_HOLOCHAIN_INFRA_BUCKETS_ACCESS:
-        required: false
+        required: true
       HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET:
-        required: false
+        required: true
+      CACHIX_AUTH_TOKEN:
+        required: true
 
 jobs:
   run-scenarios:
@@ -101,15 +103,20 @@ jobs:
       - name: Build scenario
         run: nix build .#packages.x86_64-linux.${{ steps.read-nomad-vars.outputs.scenario_name }}
 
-      - name: Upload scenario as artifact
+      - name: Upload scenario to bucket
         id: upload-scenario
-        uses: actions/upload-artifact@v6
-        with:
-          path: |
-            ./result/bin/
-            ./result/happs/
-          name: ${{ matrix.job-name }}
-          if-no-files-found: error
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_ACCESS }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET }}
+          AWS_DEFAULT_REGION: hel1
+          AWS_ENDPOINT_URL: https://hel1.your-objectstorage.com
+          S3_BUCKET_NAME: wind-tunnel-public-artifacts
+        run: |-
+          OUT_PATH="${S3_BUCKET_NAME}/run-artifacts/${{ github.run_id }}/${{ steps.read-nomad-vars.outputs.scenario_name }}.zip"
+          nix run .#awscli-s3 cp ./result/${{ steps.read-nomad-vars.outputs.scenario_name }}.zip "s3://${OUT_PATH}"
+
+          echo "scenario_download_url=${AWS_ENDPOINT_URL}/${OUT_PATH}" >> "$GITHUB_OUTPUT"
+          echo "Uploaded run scenario artifact to ${AWS_ENDPOINT_URL}/${OUT_PATH}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Wait For Minimum Free Nodes
         timeout-minutes: 30
@@ -132,16 +139,6 @@ jobs:
           done
           echo "done"
 
-      - name: Get Download URL
-        id: get-download-url
-        run: |
-          DOWNLOAD_URL=$(curl -Ls -o /dev/null -w %{url_effective} \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ github.token }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/holochain/wind-tunnel/actions/artifacts/${{ steps.upload-scenario.outputs.artifact-id}}/zip")
-          echo "download-url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
-
       - name: Run Nomad Job
         id: run-nomad-job
         env:
@@ -149,7 +146,7 @@ jobs:
           NOMAD_ADDR: https://nomad-server-01.holochain.org:4646
           NOMAD_CACERT: "${{ github.workspace }}/nomad/server-ca-cert.pem"
           NOMAD_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
-          NOMAD_VAR_scenario_url: ${{ steps.get-download-url.outputs.download-url }}
+          NOMAD_VAR_scenario_url: ${{ steps.upload-scenario.outputs.scenario_download_url }}
           NOMAD_VAR_run_id: ${{ env.RUN_ID }}
           NOMAD_VAR_holochain_bin_url: ${{ inputs.holochain-bin-url }}
         run: |-
@@ -374,6 +371,35 @@ jobs:
           S3_BUCKET_NAME: wind-tunnel-artifacts
         run: |-
           OUT_PATH="${S3_BUCKET_NAME}/summariser-reports/${{ steps.generate-summary-id.outputs.summary_id }}.json"
-          nix run .#awscli-s3-cp summariser-report-*.json "s3://${OUT_PATH}"
+          nix run .#awscli-s3 cp summariser-report-*.json "s3://${OUT_PATH}"
 
           echo "Uploaded run summary to ${AWS_ENDPOINT_URL}/${OUT_PATH}" >> "$GITHUB_STEP_SUMMARY"
+
+  cleanup:
+    name: Cleanup scenario artifacts
+    runs-on: ubuntu-latest
+    needs: wait-for-jobs
+    if: always()
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Setup cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: holochain-ci
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Delete scenarios from bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_ACCESS }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET }}
+          AWS_DEFAULT_REGION: hel1
+          AWS_ENDPOINT_URL: https://hel1.your-objectstorage.com
+          S3_BUCKET_NAME: wind-tunnel-public-artifacts
+        run: |-
+          nix run .#awscli-s3 -- rm "s3://${S3_BUCKET_NAME}/run-artifacts/${{ github.run_id }}" --recursive
+
+          echo "Deleted ${AWS_ENDPOINT_URL}/${S3_BUCKET_NAME}/run-artifacts/${{ github.run_id }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nomad-demo.yaml
+++ b/.github/workflows/nomad-demo.yaml
@@ -24,6 +24,9 @@ jobs:
     secrets:
       NOMAD_ACCESS_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
       INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+      HETZNER_HOLOCHAIN_INFRA_BUCKETS_ACCESS: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_ACCESS }}
+      HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET }}
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       holochain-bin-url: ${{ inputs.holochain_bin_url != '' && inputs.holochain_bin_url || 'https://github.com/holochain/holochain/releases/download/holochain-0.5.6/holochain-go-pion-unstable-x86_64-unknown-linux-gnu' }}
       commit-hash: ${{ inputs.commit-hash }}

--- a/README.md
+++ b/README.md
@@ -646,15 +646,8 @@ Run:
 nix build .#packages.x86_64-linux.app_install
 ```
 
-Replace `app_install` with the name of the scenario that you want to run.
-This will build the scenario, the output will be in your `/nix/store/` with a symlink to it in your local
-with the name `./result`, zip the files found in the results directory, keeping the directory structure.
-
-An example to do this is with:
-
-```bash
-mkdir app_install && cp -r result/* app_install/ && cd app_install && zip -r app_install.zip . && cd -
-```
+This will build the scenario and its required hApps in your Nix store along with a zip of the binary and hApps.
+A symlink will then be created to this derivation from the root directory with the name `result`.
 
 You now need to upload the scenario zip file to somewhere public so that the Nomad client can download it.
 This could be a GitHub release, a public file sharing services, or some other means, as long as it's publicly

--- a/flake.nix
+++ b/flake.nix
@@ -400,8 +400,8 @@
               ./summary-visualiser/generate.sh "$1" > "$2"
             '';
           };
-          awscli-s3-cp = pkgs.writeShellApplication {
-            name = "awscli-s3-cp";
+          awscli-s3 = pkgs.writeShellApplication {
+            name = "awscli-s3";
             runtimeInputs = [
               pkgs.awscli2
             ];
@@ -409,7 +409,7 @@
               set -euo pipefail
 
               # shellcheck disable=SC1091
-              aws s3 cp "$1" "$2"
+              aws s3 "$@"
             '';
           };
           rust-smoke-test = pkgs.writeShellApplication {

--- a/nix/modules/scenario.nix
+++ b/nix/modules/scenario.nix
@@ -45,7 +45,7 @@ in
         # No sources to copy, everything comes from the build inputs
         unpackPhase = "true";
 
-        buildInputs = [ scenarioBinary scenarioHapps ];
+        buildInputs = [ scenarioBinary scenarioHapps pkgs.zip ];
 
         # To tell `nix run` which binary to run. It gets it right anyway because there is only one binary but
         # it prints an annoying warning message.
@@ -59,6 +59,8 @@ in
 
           mkdir -p $out/happs
           cp ${scenarioHapps}/.happ-build ${scenarioHapps}/*.happ $out/happs
+
+          cd $out && zip -r ${name}.zip bin happs
         '';
       };
   };


### PR DESCRIPTION
### Summary
Resolves #419 

Resolves https://github.com/holochain/wind-tunnel/issues/440

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Builds now produce ZIP archives of each build for distribution.
  * CI adds cleanup jobs to remove uploaded archived artifacts from cloud storage.

* **Changes**
  * Scenario uploads now go directly to cloud storage and produce downloadable URLs.
  * CLI wrapper renamed and now forwards all provided S3-style arguments.
  * CI workflow secrets updated; additional secrets added and some made required.

* **Documentation**
  * README updated with public artifact hosting and Nomad usage guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->