### PR TITLE
ci: increase timeout buffer for Nomad jobs

### DIFF
--- a/.github/workflows/nomad-common.yaml
+++ b/.github/workflows/nomad-common.yaml
@@ -248,7 +248,7 @@ jobs:
           started_at=${{ matrix.started_at }}
           duration=${{ matrix.duration }}
           current_time=$(date +%s)
-          buffer=300
+          buffer=600
           # set timeout to $duration + $buffer (seconds $buffer) - ($current_time - $started_at)
           remaining=$(( duration - (current_time - started_at) ))
           export TIMEOUT=$(( $remaining + $buffer ))


### PR DESCRIPTION
### Summary

Uploading the metrics sometimes takes more than 5 minutes so a buffer of 5 minutes is not long enough to ensure the job finishes.

For example, [this job](https://github.com/holochain/wind-tunnel/actions/runs/20780655259/job/59681277813) failed due to a timeout because uploading the metrics took ~7 minutes and we only allow for 5 minutes because the duration that is used to calculate the timeout is the duration of the scenario and not including the setup and teardown.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased wait buffer for job allocation processes from 5 to 10 minutes to improve stability.
  * Added a safety check to ensure computed timeouts never fall below the required minimum, preventing negative or too-short wait windows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->