### PR TITLE
feat: stop running agents when their behaviour returns an error

### DIFF
--- a/framework/runner/src/run.rs
+++ b/framework/runner/src/run.rs
@@ -220,6 +220,8 @@ pub fn run<RV: UserValuesConstraint, V: UserValuesConstraint>(
                                     log::error!(
                                         "Agent behaviour [{assigned_behaviour}] failed for agent {agent_name}: {e:?}"
                                     );
+                                    behaviour_ran_to_complete = false;
+                                    break;
                                 }
                             }
                         }


### PR DESCRIPTION
### Summary

When a behaviour returns an error, the Wind Tunnel agent currently just logs the error and repeatedly runs the behaviour. This means that if there is an unrecoverable error then the behaviour just constantly runs, fails, and spams the logs. This change makes it so that if the behaviour fails then the agent running it gets stopped, if the scenario wants to ignore certain errors then that should be handled by the behaviour itself.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed agent error handling to properly mark execution state as incomplete and exit early when unexpected errors occur during agent behavior execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->