### PR TITLE
ci: log nomad output to debug exit code 2 failure on run_nomad

### DIFF
--- a/.github/workflows/nomad-common.yaml
+++ b/.github/workflows/nomad-common.yaml
@@ -158,7 +158,7 @@ jobs:
           if [ "$nomad_rc" -ne 0 ]; then
               echo "Nomad job submission failed with exit code $nomad_rc"
               echo "$nomad_output"
-              exit "nomad_rc"
+              exit "$nomad_rc"
           fi
           echo "$nomad_output"
           echo "Ran ${JOB_NAME} with run ID ${RUN_ID}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Summary

provides a way to debug #417

I wasn't able to reproduce this issue. The idea is to show output so as soon as it happens again we can open a new issue to actually fix it.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow logging with command tracing for clearer diagnostics.
  * Added robust error handling for job submissions to detect failures early, report exit codes, and emit job output on error.
  * Preserved existing success behavior while ensuring allocation extraction validates and reports when no allocations are produced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->