### PR TITLE
docs: update the changelog to match the template where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,40 +6,45 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## \[[0.5.0-dev.0](https://github.com/holochain/wind-tunnel/compare/v0.4.0-dev.1...v0.5.0-dev.0)\] - 2025-07-16
 
-### Added
+### Features
+
+- Update to use holochain  0.5 by @zippy in [#182](https://github.com/holochain/wind-tunnel/pull/182)
+
+### Miscellaneous Tasks
+
+- Prepare next release by @cdunster in [#224](https://github.com/holochain/wind-tunnel/pull/224)
+- Add `holochain_serialized_bytes` dependency by @cdunster in [#213](https://github.com/holochain/wind-tunnel/pull/213)
+  - Required with the latest version of holochain.
+- Use workspace package properties (#198) by @ThetaSinner in [#198](https://github.com/holochain/wind-tunnel/pull/198)
+- Maintenance update versions by @ThetaSinner in [#192](https://github.com/holochain/wind-tunnel/pull/192)
+
+### CI
 
 - Add job to comment the changelog preview on PRs by @cdunster in [#221](https://github.com/holochain/wind-tunnel/pull/221)
-- Add missing CACHIX_AUTH_TOKEN env to cachix push step by @cdunster in [#219](https://github.com/holochain/wind-tunnel/pull/219)
-- Add holochain_serialized_bytes dependency by @cdunster in [#213](https://github.com/holochain/wind-tunnel/pull/213)
-
-### Changed
-
-- Markdown format the CHANGELOG.md
-- Bump holochain/actions from 1.0.0 to 1.2.0 by @dependabot[bot] in [#212](https://github.com/holochain/wind-tunnel/pull/212)
-- Update PR template for conventional commits usage by @cdunster
-- Update Cargo.lock file by @ThetaSinner
-- Update flake.lock file by @ThetaSinner in [#216](https://github.com/holochain/wind-tunnel/pull/216)
-- Update Cargo.lock file by @ThetaSinner in [#203](https://github.com/holochain/wind-tunnel/pull/203)
-- Update flake.lock file by @ThetaSinner in [#201](https://github.com/holochain/wind-tunnel/pull/201)
-- Bump AdityaGarg8/remove-unwanted-software from 2 to 5 by @dependabot[bot] in [#195](https://github.com/holochain/wind-tunnel/pull/195)
-- Bump peter-evans/create-pull-request from 6 to 7 (#194) by @dependabot[bot] in [#194](https://github.com/holochain/wind-tunnel/pull/194)
-- Use workspace package properties (#198) by @ThetaSinner in [#198](https://github.com/holochain/wind-tunnel/pull/198)
-- Add release support (#193) by @ThetaSinner in [#193](https://github.com/holochain/wind-tunnel/pull/193)
-- Maintenance update versions (#192) by @ThetaSinner in [#192](https://github.com/holochain/wind-tunnel/pull/192)
-- Update flake.lock file (#191) by @github-actions[bot] in [#191](https://github.com/holochain/wind-tunnel/pull/191)
-- Enable scenarios remote_call_rate, remote_signals & two_party_countersigning on nomad cluster by @jost-s in [#188](https://github.com/holochain/wind-tunnel/pull/188)
+  - Only run the job on PRs and only PRs that don't have the `hra-release` label as these are the PRs that generate the real changelog.
+- Add missing `CACHIX_AUTH_TOKEN` env to cachix push step by @cdunster in [#219](https://github.com/holochain/wind-tunnel/pull/219)
+- Add release support by @ThetaSinner in [#193](https://github.com/holochain/wind-tunnel/pull/193)
+- Enable scenarios `remote_call_rate`, `remote_signals` & `two_party_countersigning` on nomad cluster by @jost-s in [#188](https://github.com/holochain/wind-tunnel/pull/188)
 - Track and reduce disk usage (#189) by @ThetaSinner in [#189](https://github.com/holochain/wind-tunnel/pull/189)
-- Update to use holochain  0.5 (#182) by @zippy in [#182](https://github.com/holochain/wind-tunnel/pull/182)
 - Use less disk space (#185) by @ThetaSinner in [#185](https://github.com/holochain/wind-tunnel/pull/185)
 - Add `ci_pass` check (#183) by @ThetaSinner in [#183](https://github.com/holochain/wind-tunnel/pull/183)
 
-### Removed
+### Documentation
 
-- Remove empty changelog headings and add missing release
+- Markdown format the CHANGELOG.md by @cdunster
+- Remove empty changelog headings and add missing release by @cdunster
+- Update PR template for conventional commits usage by @cdunster
+
+### Automated Changes
+
+- *(deps)* Bump holochain/actions from 1.0.0 to 1.2.0 by @dependabot[bot] in [#212](https://github.com/holochain/wind-tunnel/pull/212)
+- *(deps)* Bump AdityaGarg8/remove-unwanted-software from 2 to 5 by @dependabot[bot] in [#195](https://github.com/holochain/wind-tunnel/pull/195)
+- *(deps)* Bump peter-evans/create-pull-request from 6 to 7 (#194) by @dependabot[bot] in [#194](https://github.com/holochain/wind-tunnel/pull/194)
 
 ### First-time Contributors
 
-* @zippy made their first contribution in [#182](https://github.com/holochain/wind-tunnel/pull/182)
+- @dependabot[bot] made their first contribution in [#212](https://github.com/holochain/wind-tunnel/pull/212)
+- @zippy made their first contribution in [#182](https://github.com/holochain/wind-tunnel/pull/182)
 
 ## \[[0.4.0-dev.1](https://github.com/holochain/wind-tunnel/compare/0.2.0-alpha.2...v0.4.0-dev.1)\] - 2025-06-19
 


### PR DESCRIPTION
### Summary

Because the changelog doesn't currently match the template then `git-cliff` doesn't generate the new entries correctly.

I've fixed the header; footer; and the headings for all versions, but I've only updated the entries for the latest version because we weren't using conventional commits before that and manually updating all the entries was too much work and I don't think it's worth it.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized changelog sections and category headings for improved clarity in documenting changes.
  * Updated release header information with enhanced reference links.
  * Introduced new subsections for CI-related tasks and documentation updates.
  * Reclassified existing entries under the new organizational structure to better reflect current release management practices and automated changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->