### PR TITLE
ci: fix reference to `holochain-bin-url` variable

### DIFF
--- a/.github/workflows/nomad-demo.yaml
+++ b/.github/workflows/nomad-demo.yaml
@@ -28,7 +28,7 @@ jobs:
       HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET: ${{ secrets.HETZNER_HOLOCHAIN_INFRA_BUCKETS_SECRET }}
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
-      holochain-bin-url: ${{ inputs.holochain_bin_url != '' && inputs.holochain_bin_url || 'https://github.com/holochain/holochain/releases/download/holochain-0.5.6/holochain-go-pion-unstable-x86_64-unknown-linux-gnu' }}
+      holochain-bin-url: ${{ inputs.holochain-bin-url != '' && inputs.holochain-bin-url || 'https://github.com/holochain/holochain/releases/download/holochain-0.5.6/holochain-go-pion-unstable-x86_64-unknown-linux-gnu' }}
       commit-hash: ${{ inputs.commit-hash }}
       nomad-job-variant-directory: "nomad/job-variants/demo"
       enable-summary-uploads: false


### PR DESCRIPTION
### Summary

The variable name was recently changed but the reference to it was not updated to the new name.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration with no observable impact on functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->