### PR TITLE
ci: Run `archive_bundle` step in ci only if nix files changed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Flake for Holochain testing"; # force archive_bundle
+  description = "Flake for Holochain testing";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";


### PR DESCRIPTION
### Summary

Added a new step to test.yml which checks whether nix files changed.

The flag is provided to `archive_bundle` which in case it is `true` runs.

closes #472

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now detects changes to configuration/Nix files and exposes that result to conditionally gate workflow steps.
  * Several CI steps (installation, caching, build-space setup, platform-specific builds and packaging) are now conditional and run only when configuration changes are detected, reducing unnecessary runs and speeding workflows.
  * Minor metadata description tweak with no behavioral change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->