### PR TITLE
ci: fix pkill call in kitsune2 test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -221,7 +221,7 @@ jobs:
           nix run .#rust-smoke-test -- --package kitsune_continuous_flow -- --bootstrap-server-url "http://$kitsune_host" --signal-server-url "ws://$kitsune_host" --duration 15 --agents 2
 
           # Stop servers
-          pkill kitsune2-bootstrap-srv || true
+          pkill -f kitsune2-bootstrap-srv || true
 
           echo "==> Available space after step"
           echo


### PR DESCRIPTION
### Summary

The CI is running forever because it fails to kill the kitsune2 bootstrap service in one of the tests, this is due to the fact that the argument to the `pkill` command was recently extended to be over the 15 character limit so the process is never ended and the GitHub job just keeps running.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure for improved process handling in smoke tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->