### PR TITLE
fix: ensure local_signals metrics written on early exit

### DIFF
--- a/scenarios/local_signals/src/main.rs
+++ b/scenarios/local_signals/src/main.rs
@@ -39,7 +39,6 @@ fn agent_behaviour(
     let _metrics_guard = MetricsGuard {
         write_fn: Box::new({
             let reporter = reporter.clone();
-            let start = start.clone();
             let received_count = received_count.clone();
             move || {
                 let recv_elapsed_s = start.elapsed().as_secs_f64();


### PR DESCRIPTION
Fixes https://github.com/holochain/wind-tunnel/issues/427

The local_signals scenario was failing in CI because metrics were only written at the end of the agent_behaviour function. If the scenario duration ended while waiting for signals (30s timeout), the function would be interrupted and metrics would never be written.

This fix implements a MetricsGuard using Rust's RAII pattern with Drop to ensure recv metrics are always written when the function exits, whether normally or through early termination. The send metric is now written immediately after the zome call completes.

Changes:
  - Move start timer to beginning of function
  - Create MetricsGuard that writes metrics in Drop implementation
  - Write send metric immediately after zome call
  - Recv metrics automatically written on function exit (normal or early)

Tested with 5/5 stress tests passing with 20s duration (previously failed 100% of the time).

### Summary



### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Receive metrics are now reliably recorded even on early exit or unexpected termination.
  * Send metrics are emitted immediately after actions complete.
  * Final receive/send metrics are now emitted automatically at run end, replacing previous manual emission steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->