### PR TITLE
fix: use_influx script properly parses influx token

### DIFF
--- a/scripts/influx.sh
+++ b/scripts/influx.sh
@@ -16,7 +16,8 @@ export INFLUX_CONFIGS_PATH
 use_influx() {
     export INFLUX_HOST="http://localhost:8087"
     export INFLUX_BUCKET="windtunnel"
-    INFLUX_TOKEN="$(tq --file "$INFLUX_CONFIGS_PATH" .default.token)"
+    # The --raw flag ensures output does not include the quote characters.
+    INFLUX_TOKEN="$(tq --file "$INFLUX_CONFIGS_PATH" --raw .default.token)"
     export INFLUX_TOKEN
 }
 


### PR DESCRIPTION
### Summary
The `--raw` flag was removed in https://github.com/holochain/wind-tunnel/pull/295. This caused the parsed string to include wrapping quote characters, so it was no longer valid.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed InfluxDB token retrieval so token values are read without surrounding formatting characters. This prevents mis-parsed tokens, reduces authentication failures, and improves reliability when connecting to InfluxDB.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->