### PR TITLE
fix: hApps fetched from URL are now placed in a directory as required

### DIFF
--- a/happ_builder/tests/fetch_integration.rs
+++ b/happ_builder/tests/fetch_integration.rs
@@ -46,7 +46,7 @@ fn should_fetch_happ() {
         .ensure_happs_available()
         .expect("failed to fetch happ");
 
-    let fetched_happ_path = happ_target_dir.join("dino-adventure.happ");
+    let fetched_happ_path = happ_target_dir.join("dino-adventure/dino-adventure.happ");
     assert!(
         fetched_happ_path.exists(),
         "fetched happ file does not exist"
@@ -60,8 +60,8 @@ fn should_refetch_if_hash_mismatch() {
     let happ_target_dir = tempdir.path().join("happs");
 
     // Create happs directory and a corrupted file
-    std::fs::create_dir_all(&happ_target_dir).expect("failed to create happs dir");
-    let file_path = happ_target_dir.join("dino-adventure.happ");
+    let file_path = happ_target_dir.join("dino-adventure/dino-adventure.happ");
+    std::fs::create_dir_all(file_path.parent().unwrap()).expect("failed to create happs dir");
     std::fs::write(&file_path, b"corrupted data").expect("failed to write test file");
 
     // Create test manifest


### PR DESCRIPTION
### Summary

This is required to unblock #457.

Fetching hApps from a URL currently doesn't put the fetched hApp in a sub-directory so the macro looks in the wrong place, this needs to be fixed.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Writes packages into a nested per-package directory for clearer organization.
  * Ensures output directories are created before writing to avoid failures.
  * Cleans up incomplete files and their containing directories on write errors or checksum mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->