### PR TITLE
fix: hApps fetched from URL are placed in correct directory

### DIFF
--- a/happ_builder/src/fetch.rs
+++ b/happ_builder/src/fetch.rs
@@ -1,24 +1,21 @@
-use crate::HappBuilderResult;
 use crate::manifest::{FetchRequiredHapp, Sha256Hash};
+use crate::{HappBuilderResult, HappManagerOptions};
 use anyhow::Context;
 use sha2::Sha256;
 use std::path::Path;
 use std::time::Duration;
 
 pub struct HappFetcher<'a> {
-    /// Directory to fetch happs into
-    pub happ_target_dir: &'a Path,
+    /// The options for configuring the hApp manager and details from the manifest
+    options: &'a HappManagerOptions,
     /// Happs to fetch
     pub happs: &'a [FetchRequiredHapp],
 }
 
 impl<'a> HappFetcher<'a> {
     /// Create a new [`HappFetcher`]
-    pub fn new(happ_target_dir: &'a Path, happs: &'a [FetchRequiredHapp]) -> Self {
-        Self {
-            happ_target_dir,
-            happs,
-        }
+    pub fn new(options: &'a HappManagerOptions, happs: &'a [FetchRequiredHapp]) -> Self {
+        Self { options, happs }
     }
 }
 
@@ -35,8 +32,10 @@ impl HappFetcher<'_> {
     /// Fetch a single happ and save it to the target directory
     fn fetch_happ(&self, happ: &FetchRequiredHapp) -> HappBuilderResult {
         let out_path = self
+            .options
             .happ_target_dir
-            .join(format!("{name}/{name}.happ", name = &happ.name));
+            .join(&self.options.package_name)
+            .join(format!("{name}.happ", name = &happ.name));
 
         if out_path.exists()
             && let Ok(existing_sha256) = Self::sha256_file(&out_path)

--- a/happ_builder/src/lib.rs
+++ b/happ_builder/src/lib.rs
@@ -106,11 +106,7 @@ impl HappManager {
         .build_happs()?;
 
         // fetch
-        HappFetcher::new(
-            &self.options.happ_target_dir,
-            &metadata.fetch_required_happ(),
-        )
-        .fetch_all()?;
+        HappFetcher::new(&self.options, &metadata.fetch_required_happ()).fetch_all()?;
 
         Ok(())
     }

--- a/happ_builder/tests/fetch_integration.rs
+++ b/happ_builder/tests/fetch_integration.rs
@@ -46,7 +46,7 @@ fn should_fetch_happ() {
         .ensure_happs_available()
         .expect("failed to fetch happ");
 
-    let fetched_happ_path = happ_target_dir.join("dino-adventure/dino-adventure.happ");
+    let fetched_happ_path = happ_target_dir.join("test-package/dino-adventure.happ");
     assert!(
         fetched_happ_path.exists(),
         "fetched happ file does not exist"
@@ -60,7 +60,7 @@ fn should_refetch_if_hash_mismatch() {
     let happ_target_dir = tempdir.path().join("happs");
 
     // Create happs directory and a corrupted file
-    let file_path = happ_target_dir.join("dino-adventure/dino-adventure.happ");
+    let file_path = happ_target_dir.join("test-package/dino-adventure.happ");
     std::fs::create_dir_all(file_path.parent().unwrap()).expect("failed to create happs dir");
     std::fs::write(&file_path, b"corrupted data").expect("failed to write test file");
 


### PR DESCRIPTION
### Summary

Ooops, in the last PR #510 I set the download directory to the same name as the hApp but it should actually be the name of the scenario package (I think). 2nd time's the charm? :crossed_fingers:

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch

_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Initialization now uses a centralized options object; fetched happs are saved under a package-name subdirectory, changing where downloaded files are placed.

* **Tests**
  * Integration tests updated to expect package-name-based output paths so assertions match the revised file locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->