### PR TITLE
fix: warning and error in telegraf log resolved

### DIFF
--- a/telegraf/telegraf.host.conf
+++ b/telegraf/telegraf.host.conf
@@ -53,7 +53,7 @@
   ## If set to true, do no set the "host" tag in the telegraf agent.
   omit_hostname = false
 
-  ## Run processors after aggregator plugins (default will change to true in v1.40.0, currently avoids a warning to set it)
+  ## Skip running processors after aggregator plugins (default will change to true in v1.40.0, currently avoids a warning to set it)
   skip_processors_after_aggregators = true
 
 ###############################################################################


### PR DESCRIPTION
### Summary



### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added skip_processors_after_aggregators configuration option (defaults to true in v1.40.0) to adjust processor behavior and avoid a startup warning.
  * Added ignore_protocol_stats configuration option (deprecated) to suppress protocol-statistics deprecation warnings; use inputs.nstat for protocol stats if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->