### PR TITLE
fix: dont round before selecting values within 2 std and 3 std

### DIFF
--- a/summariser/src/analyze.rs
+++ b/summariser/src/analyze.rs
@@ -33,12 +33,10 @@ pub(crate) fn standard_timing_stats(
                 .and(col(column).lt_eq(lit(mean + std)))
                 .alias("within_std"),
             col(column)
-                .round(2, RoundMode::default())
                 .gt_eq(lit(mean - 2.0 * std))
                 .and(col(column).lt_eq(lit(mean + 2.0 * std)))
                 .alias("within_2std"),
             col(column)
-                .round(2, RoundMode::default())
                 .gt_eq(lit(mean - 3.0 * std))
                 .and(col(column).lt_eq(lit(mean + 3.0 * std)))
                 .alias("within_3std"),

--- a/summariser/test_data/3_summary_outputs/app_install-52bd6609472c523e0561f09d7daecaac880d348f71241f6fabf71d28795e79ec.json
+++ b/summariser/test_data/3_summary_outputs/app_install-52bd6609472c523e0561f09d7daecaac880d348f71241f6fabf71d28795e79ec.json
@@ -35,7 +35,7 @@
       "mean": 0.099259,
       "std": 0.008681,
       "within_std": 0.6495,
-      "within_2std": 0.9484,
+      "within_2std": 0.9634,
       "within_3std": 0.9978,
       "trend": {
         "trend": [

--- a/summariser/test_data/3_summary_outputs/dht_sync_lag-3a1e33ccf661bd873966c539d4d227e703e1496fb54bb999f7be30a3dd493e51.json
+++ b/summariser/test_data/3_summary_outputs/dht_sync_lag-3a1e33ccf661bd873966c539d4d227e703e1496fb54bb999f7be30a3dd493e51.json
@@ -176,8 +176,8 @@
       "mean": 0.000048,
       "std": 0.000014,
       "within_std": 0.8533,
-      "within_2std": 0.0,
-      "within_3std": 0.0,
+      "within_2std": 0.9784,
+      "within_3std": 0.9931,
       "trend": {
         "trend": [
           0.000042,
@@ -234,8 +234,8 @@
         "mean": 0.00054,
         "std": 0.0,
         "within_std": 1.0,
-        "within_2std": 0.0,
-        "within_3std": 0.0,
+        "within_2std": 1.0,
+        "within_3std": 1.0,
         "trend": {
           "trend": [],
           "window_duration": "10s"
@@ -245,8 +245,8 @@
         "mean": 0.000697,
         "std": 0.000017,
         "within_std": 0.5,
-        "within_2std": 0.0,
-        "within_3std": 0.0,
+        "within_2std": 1.0,
+        "within_3std": 1.0,
         "trend": {
           "trend": [],
           "window_duration": "10s"
@@ -257,8 +257,8 @@
       "mean": 0.000523,
       "std": 0.0,
       "within_std": 1.0,
-      "within_2std": 0.0,
-      "within_3std": 0.0,
+      "within_2std": 1.0,
+      "within_3std": 1.0,
       "trend": {
         "trend": [],
         "window_duration": "10s"
@@ -268,8 +268,8 @@
       "mean": 0.000366,
       "std": 0.0,
       "within_std": 1.0,
-      "within_2std": 0.0,
-      "within_3std": 0.0,
+      "within_2std": 1.0,
+      "within_3std": 1.0,
       "trend": {
         "trend": [],
         "window_duration": "10s"
@@ -340,7 +340,7 @@
       "mean": 0.000053,
       "std": 0.00002,
       "within_std": 0.7479,
-      "within_2std": 0.0,
+      "within_2std": 0.9548,
       "within_3std": 0.9923,
       "trend": {
         "trend": [

--- a/summariser/test_data/3_summary_outputs/remote_call_rate-f92e98962b23bfe104373a735dd9af8eb363e347a0c528902d4a2aaa8351cd74.json
+++ b/summariser/test_data/3_summary_outputs/remote_call_rate-f92e98962b23bfe104373a735dd9af8eb363e347a0c528902d4a2aaa8351cd74.json
@@ -48,8 +48,8 @@
             "mean": 0.001576,
             "std": 0.00031,
             "within_std": 0.9864,
-            "within_2std": 0.0,
-            "within_3std": 0.0,
+            "within_2std": 0.9894,
+            "within_3std": 0.9902,
             "trend": {
               "trend": [
                 0.001585,
@@ -77,8 +77,8 @@
             "mean": 0.001563,
             "std": 0.000288,
             "within_std": 0.9838,
-            "within_2std": 0.0,
-            "within_3std": 0.0,
+            "within_2std": 0.9886,
+            "within_3std": 0.9899,
             "trend": {
               "trend": [
                 0.00156,
@@ -112,7 +112,7 @@
             "mean": 0.003495,
             "std": 0.001218,
             "within_std": 0.9775,
-            "within_2std": 0.0141,
+            "within_2std": 0.9948,
             "within_3std": 0.9952,
             "trend": {
               "trend": [
@@ -141,7 +141,7 @@
             "mean": 0.003491,
             "std": 0.001175,
             "within_std": 0.9746,
-            "within_2std": 0.0141,
+            "within_2std": 0.9922,
             "within_3std": 0.9947,
             "trend": {
               "trend": [

--- a/summariser/test_data/3_summary_outputs/single_write_many_read-53072be05686ee83ae234f248d2791e0576cdc05065954975b89549571613a97.json
+++ b/summariser/test_data/3_summary_outputs/single_write_many_read-53072be05686ee83ae234f248d2791e0576cdc05065954975b89549571613a97.json
@@ -34,8 +34,8 @@
       "mean": 0.001698,
       "std": 0.000365,
       "within_std": 0.9825,
-      "within_2std": 0.0,
-      "within_3std": 0.0,
+      "within_2std": 0.9875,
+      "within_3std": 0.9886,
       "trend": {
         "trend": [
           0.001631,

--- a/summariser/test_data/3_summary_outputs/zome_call_single_value-4e74c47aa5158bbdc0c010fdc44de565c8b6592e472026f0bca9464d69e1e99b.json
+++ b/summariser/test_data/3_summary_outputs/zome_call_single_value-4e74c47aa5158bbdc0c010fdc44de565c8b6592e472026f0bca9464d69e1e99b.json
@@ -34,8 +34,8 @@
       "mean": 0.001499,
       "std": 0.000287,
       "within_std": 0.977,
-      "within_2std": 0.0,
-      "within_3std": 0.0,
+      "within_2std": 0.988,
+      "within_3std": 0.9889,
       "trend": {
         "trend": [
           0.001488,


### PR DESCRIPTION
### Summary
Previously we were rounding values before selecting those within 2 and 3 std for timing stats fields `within_2std` and `within_3std`. This caused some unexpected results where the percentage of values within 1 std was greater than the percentage of values within 2 or 3 std.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced precision in timing statistics. Standard deviation coverage metrics now provide more accurate measurements across performance scenarios and benchmarks, including dispatch timing, workflow durations, and database connection metrics. This ensures more reliable statistical visibility without affecting system functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->