### PR TITLE
fix: snapshot test should only load exected output when asserting it

### DIFF
--- a/summariser/tests/snapshot.rs
+++ b/summariser/tests/snapshot.rs
@@ -14,13 +14,6 @@ macro_rules! run_snapshot_test {
             std::fs::File::open(run_summary.path()).context("Failed to load run summary")?,
         )?;
 
-        let expected = find_test_data_file($summary_fingerprint, "3_summary_outputs")
-            .context("Summary output not found")?;
-        let expected = serde_json::from_reader::<_, SummaryOutput>(
-            std::fs::File::open(expected.path())
-                .context("Failed to load expected summary output")?,
-        )?;
-
         let output = execute_report_for_run_summary(
             influxdb::Client::new("http://never-connect", "test"),
             run_summary,
@@ -32,6 +25,13 @@ macro_rules! run_snapshot_test {
         if option_env!("UPDATE_SNAPSHOTS") == Some("1") {
             holochain_summariser::test_data::insert_summary_output(&output, true)?;
         } else {
+            let expected = find_test_data_file($summary_fingerprint, "3_summary_outputs")
+                .context("Summary output not found")?;
+            let expected = serde_json::from_reader::<_, SummaryOutput>(
+                std::fs::File::open(expected.path())
+                    .context("Failed to load expected summary output")?,
+            )?;
+
             pretty_assertions::assert_eq!(expected, output, "Snapshot mismatch, run with `UPDATE_SNAPSHOTS=1 cargo test --test snapshot` to update");
         }
     };


### PR DESCRIPTION
### Summary
Previously adding a field to an existing summariser type, and then running `UPDATE_SNAPSHOTS=1 cargo test --test snapshot` would fail, because it attempts to load the existing snapshot test assertion output and decode it to that type, which fails.


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reordered snapshot test flow so expected outputs are loaded after generating actual outputs, improving error context and consistency while leaving snapshot-update behavior unchanged.

---

**Note:** This release contains no user-facing changes; updates are internal testing improvements only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->