### PR TITLE
ci: nomad-common.yaml is reading `behaviours` from the scenario file, but it should actually read `assignments`

### DIFF
--- a/.github/workflows/nomad-common.yaml
+++ b/.github/workflows/nomad-common.yaml
@@ -81,8 +81,8 @@ jobs:
           JOB_VARS_FILE="${{ inputs.nomad-job-variant-directory }}/vars/${{ matrix.job-name }}.json"
           NOMAD_VAR_DURATION="$(jq -e -r '.duration' "$JOB_VARS_FILE")"
           NOMAD_VAR_SCENARIO_NAME="$(jq -e -r '.scenario_name' "$JOB_VARS_FILE")"
-          # Parse required nodes count from length of 'behaviours' list, or else default to 1.
-          REQUIRED_NODES="$(jq -e -r '.behaviours // 1 | length' "$JOB_VARS_FILE")"
+          # Parse required nodes count by summing the 'nodes' field of each assignment (defaulting to 1 per entry), or else default to 1 if no assignments.
+          REQUIRED_NODES="$(jq -e -r 'if .assignments then [.assignments[] | .nodes // 1] | add else 1 end' "$JOB_VARS_FILE")"
 
           echo "duration=$NOMAD_VAR_DURATION" >> "$GITHUB_OUTPUT"
           echo "scenario_name=$NOMAD_VAR_SCENARIO_NAME" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Summary



### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Nomad job resource calculation: required node counts are now determined per-assignment with a sensible default when assignments are absent, delivering more accurate node requirements. This reduces under/over-provisioning and improves the reliability and predictability of job scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->