### PR TITLE
ci: used claude code pr reviewer

### DIFF
--- a/.github/workflows/claude_pr_review.yaml
+++ b/.github/workflows/claude_pr_review.yaml
@@ -1,0 +1,37 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  claude:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read # Required for Claude to read CI results on PRs
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: |
+            https://github.com/anthropics/claude-code.git
+          plugins: |
+            pr-review-toolkit@claude-code-plugins
+          track_progress: true
+          include_fix_links: false
+          use_sticky_comment: true
+          prompt: |
+            /review ${{ github.event.pull_request.number }}
+          claude_args: |-
+            --model sonnet
+            --allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Read,Grep,Glob"
+          github_token: ${{ github.token }}


### PR DESCRIPTION
### Summary
Resolves https://github.com/holochain/holochain/issues/5625

See the review comment below, or this [example repo](https://github.com/mattyg/claude-code-pr-review-demo/pull/5) for examples of the code review.

This will make a single comment on the PR each time it is run, with the full code review. Unfortunately this makes it harder to track individual issues. I first tried a simple prompt to split up the review into multiple inline comments, but it seemed too brittle with multiple commits (see https://github.com/mattyg/claude-code-pr-review-demo/pull/4).

We can use a standard claude pro subscription for this. I think that is preferable to api credits as it limits our usage and fixes the cost. I temporarily added my personal claude pro account until we get a foundation account set up.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  - Added an automated PR review workflow using Claude AI that runs on pull request events (opened, reopened, synchronized, ready_for_review) for non-draft PRs.
  - Posts progress-enabled, sticky review comments and provides review feedback directly on PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->