### PR TITLE
ci: do not reschedule failed nomad jobs

### DIFF
--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -59,6 +59,11 @@ job "{{ (ds "vars").scenario_name }}" {
         mode = "fail"
       }
 
+      reschedule {
+        attempts  = 0
+        unlimited = false
+      }
+
       dynamic "task" {
         // Only run host metrics collector if `var.reporter` is set to `influx-file`.
         for_each = var.reporter == "influx-file" ? [var.reporter] : []


### PR DESCRIPTION
### Summary
I noticed that failed allocations are rescheduled for 24 hours later, which we don't want. This is the recommended way to disable from https://developer.hashicorp.com/nomad/docs/job-specification/reschedule#disabling-rescheduling


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated task rescheduling configuration to set zero attempts and disable unlimited retry attempts for group failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->