### PR TITLE
fix: metrics from last page of history in unyt scenario were not sent

### DIFF
--- a/scenarios/unyt_chain_transaction/src/main.rs
+++ b/scenarios/unyt_chain_transaction/src/main.rs
@@ -71,7 +71,7 @@ fn main() -> WindTunnelResult<()> {
         while let Ok(History {
             items,
             low_boundary,
-            end_of_chain: false,
+            end_of_chain,
         }) = ctx.unyt_get_history(Pagination {
             high_boundary: current_boundary,
             per_page: 100,
@@ -101,6 +101,9 @@ fn main() -> WindTunnelResult<()> {
                     .with_field("parked_spends", parked_spend)
                     .with_tag("agent", ctx.get().cell_id().agent_pubkey().to_string()),
             );
+            if end_of_chain {
+                break;
+            }
         }
 
         log::info!("uninstalling agent {}", ctx.get().cell_id().agent_pubkey());


### PR DESCRIPTION
### Summary

Fixes #548 

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Transaction history processing now correctly detects stream completion and terminates appropriately, eliminating unnecessary iterations during scenario execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->