### PR TITLE
chore: update the Unyt hApp in the Unyt Chain Transaction scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5966,11 +5966,12 @@ dependencies = [
 
 [[package]]
 name = "rave_engine"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47576c0c191871bc7bd71568a89a86953cdb0e1ba30f9bc4ad1d54d61eaba9e"
+checksum = "bae3a54eb659798faf7b469c4c322f6a0133810e4c2884db54227743d474536f"
 dependencies = [
  "chrono",
+ "getrandom 0.3.4",
  "hc_utils",
  "hdi",
  "hdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ kitsune2_gossip = "0.4.0-dev.2"
 kitsune2_transport_iroh = { version = "0.4.0-dev.2", default-features = false }
 
 # Deps for Unyt
-rave_engine = "0.3.0"
+rave_engine = "0.3.2"
 zfuel = "0.6.0"
 
 # Framework

--- a/scenarios/unyt_chain_transaction/Cargo.toml
+++ b/scenarios/unyt_chain_transaction/Cargo.toml
@@ -32,5 +32,5 @@ workspace = true
 
 [package.metadata.fetch-required-happ]
 name = "unyt"
-url = "https://github.com/unytco/unyt-sandbox/releases/download/v0.50.0/unyt.happ"
-sha256 = "77aa53bd9c549da6b4b259dd4e09fdd146d6f6c078640240c8324d47da1ac929"
+url = "https://github.com/unytco/unyt-sandbox/releases/download/v0.55.0/unyt.happ"
+sha256 = "e48f016b75d2b2f24e885e88c56e9235b2f453119268131445593be1d759365c"

--- a/scenarios/unyt_chain_transaction/src/behaviour/initiate_network.rs
+++ b/scenarios/unyt_chain_transaction/src/behaviour/initiate_network.rs
@@ -2,7 +2,7 @@ use crate::{ScenarioValues, unyt_agent::UnytAgentExt};
 use holochain_types::prelude::{ActionHashB64, Timestamp};
 use holochain_wind_tunnel_runner::prelude::*;
 use rave_engine::types::{
-    InitializeGlobalDefinition, PermissionSpace, UnitIndexMap,
+    InitializeGlobalDefinition, Oracles, PermissionSpace, UnitIndexMap,
     entries::{
         AddressBook, AgreementDefInput, CodeTemplate, CommonRAVEAgreements, CommonSpecialAgents,
         DataFetchInstruction, EARole, ExecutionEngine, ExecutorRules, GlobalDefinition, InputRules,
@@ -50,6 +50,9 @@ pub fn agent_behaviour(
                     additional_special_agents: vec![],
                     additional_rave_agreements: vec![],
                     service_units: UnitIndexMap::new(),
+                },
+                oracles: Oracles {
+                    pricing_oracle: None,
                 },
                 system_rave_agreements: SystemRAVEAgreements {
                     compute_credit_limit: credit_limit_smart_agreement,
@@ -191,7 +194,7 @@ fn create_agreements(
                 {
                   "const": {
                     "id": "spender",
-                    "consumed_link": true
+                    "parked_link_type": "ParkedSpendBalance"
                   }
                 }
               ],

--- a/scenarios/unyt_chain_transaction/src/behaviour/smart_agreements.rs
+++ b/scenarios/unyt_chain_transaction/src/behaviour/smart_agreements.rs
@@ -61,7 +61,7 @@ pub fn agent_behaviour(
     let incoming_transactions = ctx.unyt_get_incoming_raves()?;
     for transaction in incoming_transactions {
         log::info!("Collecting incoming transaction: {:?}", transaction);
-        if let Err(err) = ctx.unyt_collect_from_rave(transaction.clone()) {
+        if let Err(err) = ctx.unyt_create_collect_from_rave(transaction.clone()) {
             log::warn!("Failed to collect from RAVE, transaction '{transaction:?}': {err}");
         }
     }
@@ -216,7 +216,7 @@ fn generate_smart_agreement(
                   {
                     "const": {
                       "id": "spender",
-                      "consumed_link": true
+                      "parked_link_type": "ParkedSpendBalance"
                     }
                   }
                 ],

--- a/scenarios/unyt_chain_transaction/src/behaviour/spend.rs
+++ b/scenarios/unyt_chain_transaction/src/behaviour/spend.rs
@@ -52,7 +52,7 @@ pub fn agent_behaviour(
         );
     }
     for transaction in actionable_transactions.commitment_actionable {
-        if let Err(err) = ctx.unyt_accept(AcceptInput {
+        if let Err(err) = ctx.unyt_create_accept(AcceptInput {
             commitment: transaction.id.clone(),
             note: None,
         }) {

--- a/scenarios/unyt_chain_transaction/src/unyt_agent.rs
+++ b/scenarios/unyt_chain_transaction/src/unyt_agent.rs
@@ -39,12 +39,18 @@ pub trait UnytAgentExt {
         commitment: CommitmentInput,
     ) -> Result<ActionHashB64, anyhow::Error>;
     fn unyt_get_actionable_transactions(&mut self) -> Result<Actionable, anyhow::Error>;
-    fn unyt_accept(&mut self, accept_input: AcceptInput) -> Result<ActionHashB64, anyhow::Error>;
+    fn unyt_create_accept(
+        &mut self,
+        accept_input: AcceptInput,
+    ) -> Result<ActionHashB64, anyhow::Error>;
     fn unyt_get_ledger(&mut self) -> Result<Ledger, anyhow::Error>;
     fn unyt_get_my_current_applied_credit_limit(&mut self) -> Result<UnitMap, anyhow::Error>;
     fn unyt_get_history(&mut self, pagination: Pagination) -> Result<History, anyhow::Error>;
     fn unyt_get_incoming_raves(&mut self) -> Result<Vec<Transaction>, anyhow::Error>;
-    fn unyt_collect_from_rave(&mut self, tx: Transaction) -> Result<ActionHashB64, anyhow::Error>;
+    fn unyt_create_collect_from_rave(
+        &mut self,
+        tx: Transaction,
+    ) -> Result<ActionHashB64, anyhow::Error>;
     fn unyt_create_parked_spend(
         &mut self,
         park: CreateParkedSpendInput,
@@ -195,8 +201,11 @@ impl UnytAgentExt for AgentContext<HolochainRunnerContext, HolochainAgentContext
         self.call_zome_alliance("get_actionable_transactions", ())
     }
 
-    fn unyt_accept(&mut self, accept_input: AcceptInput) -> Result<ActionHashB64, anyhow::Error> {
-        self.call_zome_alliance("accept", accept_input)
+    fn unyt_create_accept(
+        &mut self,
+        accept_input: AcceptInput,
+    ) -> Result<ActionHashB64, anyhow::Error> {
+        self.call_zome_alliance("create_accept", accept_input)
     }
 
     fn unyt_get_ledger(&mut self) -> Result<Ledger, anyhow::Error> {
@@ -215,8 +224,11 @@ impl UnytAgentExt for AgentContext<HolochainRunnerContext, HolochainAgentContext
         self.call_zome_alliance("get_incoming_raves", ())
     }
 
-    fn unyt_collect_from_rave(&mut self, tx: Transaction) -> Result<ActionHashB64, anyhow::Error> {
-        self.call_zome_alliance("collect_from_rave", tx)
+    fn unyt_create_collect_from_rave(
+        &mut self,
+        tx: Transaction,
+    ) -> Result<ActionHashB64, anyhow::Error> {
+        self.call_zome_alliance("create_collect_from_rave", tx)
     }
 
     fn unyt_create_parked_spend(


### PR DESCRIPTION
### Summary

The diff between the Unyt hApp v0.50.0 and v0.55.0 is: https://github.com/unytco/unyt-app/compare/ceaa7218980715471a0f87daff7eff9edaf0f40c...6bcf4e7ce270f9090eeca676ecba5baf816ce821

Closes #546 

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated HAPP artifact to v0.55.0 with matching checksum and bumped a dependency version.

* **New Features / Behavior changes**
  * Transaction handling now uses new "create"-style actions for accepting and collecting RAVE transactions.
  * Network initialization includes an oracles configuration and the spender role now expects parked spend links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->