### PR TITLE
fix: invalid metric logic and type in scenario `full_arc_create_validated_zero_arc_read` for metric `retrieval_error_count`

### DIFF
--- a/scenarios/full_arc_create_validated_zero_arc_read/src/main.rs
+++ b/scenarios/full_arc_create_validated_zero_arc_read/src/main.rs
@@ -12,6 +12,7 @@ const RECORD_OPEN_CONNECTIONS_PERIOD_MS: i64 = 3_000;
 #[derive(Debug, Default)]
 struct ScenarioValues {
     sent_actions_count: u32,
+    retrieval_errors_count: u32,
     seen_actions: HashSet<ActionHash>,
     open_connections_last_recorded: Option<Timestamp>,
 }
@@ -113,10 +114,11 @@ fn agent_behaviour_zero(
                 .insert(new_record.action_address().clone());
         }
     } else {
+        ctx.get_mut().scenario_values.retrieval_errors_count += 1;
         let metric = ReportMetric::new("retrieval_error_count")
             .with_tag("agent", agent_pub_key.clone())
             .with_tag("arc", "zero")
-            .with_field("value", 1_f64);
+            .with_field("value", ctx.get().scenario_values.retrieval_errors_count);
         reporter_handle.add_custom(metric);
     }
 


### PR DESCRIPTION
### Summary

This is causing problems because there is a type mismatch between scenarios using the same metric name and it's resulting in InfluxDB rejecting later content.

The metric was also being recorded wrong.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of error tracking by counting cumulative retrieval failures instead of reporting fixed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->