### PR TITLE
ci(claude): fixed usage of sticky_comments by removing the github token. Added directives for claude reviewer to only report errors, bugs, etc very concisely

### DIFF
--- a/.github/workflows/claude_pr_review.yaml
+++ b/.github/workflows/claude_pr_review.yaml
@@ -31,7 +31,8 @@ jobs:
           use_sticky_comment: true
           prompt: |
             /review ${{ github.event.pull_request.number }}
+
+            IMPORTANT: Be terse and concise. Only comment on genuine issues — bugs, logic errors, security problems, or clear violations of CLAUDE.md conventions. Do NOT leave praise, nitpicks, style suggestions, or comments about things that are fine. If there are no real issues, say so in one sentence. Each comment should be 1-3 sentences max. When flagging an issue, include a short code snippet showing the suggested fix.
           claude_args: |-
             --model sonnet
             --allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Read,Grep,Glob"
-          github_token: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,17 @@ Go templates and shell scripts — not a Rust crate. Renders the JSON summary ou
 - Backwards compatibility is not required to be maintained. If the source data changes, or a change is planned to the output summary statistics, then make the change directly without compatibility in mind.
 - Changes to queries that result in empty values in summary outputs for test data are not acceptable because the tests aren't exercising the code properly in that case. The user must be informed to re-generate test data when this happens.
 
+## PR Review Guidelines
+
+When reviewing pull requests:
+
+- **Be terse.** Only flag genuine issues: bugs, logic errors, security problems, or violations of project conventions documented here.
+- **Do NOT comment on:** style preferences, minor naming choices, things that are already fine, or anything that `cargo clippy` / `cargo fmt` / `taplo format` would catch (CI handles those).
+- **Do NOT leave praise or filler** like "nice work" or "looks good overall." If there are no issues, say "No issues found." and nothing else.
+- **Each comment should be 1–3 sentences.** State the problem, why it matters, and include a short code snippet showing the suggested fix.
+- **Focus on the diff.** Don't review unchanged code unless a change introduces a problem in surrounding context.
+- **Understand the architecture** before commenting. Read the relevant sections above (Framework, Bindings, Scenarios, Summariser) so your feedback is informed by how the project actually works.
+
 ## Code Hygiene
 
 - Generated Rust and TOML must always be properly formatted, if you're not sure then run `cargo fmt` or `taplo format` on the relevant files.


### PR DESCRIPTION
Fixed usage of sticky comments.

<https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md> states that: The use_sticky_comment feature only works with claude[bot] authentication

Added directives for claude to be very short in issues and to report just actual issues and not good things.

closes #543

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal review guidelines and CI/CD configuration to improve code quality processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->