### PR TITLE
feat(summary-visualizer): convert bytes to bytes unit (e.g. KB,MB,GB...)

### DIFF
--- a/summary-visualiser/templates/helpers/format_bytes.html.tmpl
+++ b/summary-visualiser/templates/helpers/format_bytes.html.tmpl
@@ -1,0 +1,22 @@
+{{/*
+  Format a byte value to human-readable (B, KiB, MiB, GiB).
+  Fields:
+  * `value` (number): The byte value to format.
+  * `label` (string, optional): A label to display before the value.
+  * `suffix` (string, optional): A suffix to append to the unit (e.g. "/s").
+  */}}<span class="scalar">
+    {{- if (index . "label") -}}
+        <span class="scalar-label">{{ .label }}</span>
+    {{- end }}
+    {{- $v := conv.ToFloat64 .value -}}
+    {{- $s := default "" (index . "suffix") -}}
+    {{- if (ge $v 1073741824.0) -}}
+        <span class="scalar-value">{{ printf "%.2f" (math.Div $v 1073741824.0) }}</span><span class="scalar-unit"> GiB{{ $s }}</span>
+    {{- else if (ge $v 1048576.0) -}}
+        <span class="scalar-value">{{ printf "%.2f" (math.Div $v 1048576.0) }}</span><span class="scalar-unit"> MiB{{ $s }}</span>
+    {{- else if (ge $v 1024.0) -}}
+        <span class="scalar-value">{{ printf "%.2f" (math.Div $v 1024.0) }}</span><span class="scalar-unit"> KiB{{ $s }}</span>
+    {{- else -}}
+        <span class="scalar-value">{{ printf "%.0f" $v }}</span><span class="scalar-unit"> B{{ $s }}</span>
+    {{- end -}}
+</span>

--- a/summary-visualiser/templates/helpers/format_bytes_rate.html.tmpl
+++ b/summary-visualiser/templates/helpers/format_bytes_rate.html.tmpl
@@ -1,0 +1,7 @@
+{{/*
+  Format a byte-rate value to human-readable (B/s, KiB/s, MiB/s, GiB/s).
+  Wraps format_bytes with a "/s" suffix.
+  Fields:
+  * `value` (number): The byte-rate value to format.
+  * `label` (string, optional): A label to display before the value.
+  */}}{{ template "format_bytes" (dict "value" .value "label" (default "" (index . "label")) "suffix" "/s") }}

--- a/summary-visualiser/templates/helpers/host_metrics.html.tmpl
+++ b/summary-visualiser/templates/helpers/host_metrics.html.tmpl
@@ -23,13 +23,13 @@ This template displays system-level performance metrics collected during the sce
         {{ template "scenario_metric" (dict
             "name" "Network receive rate (primary)"
             "description" "Rate of bytes received on primary network interface"
-            "content" (tmpl.Exec "min_max_mean_std" (merge (dict "unit" "B/s") .recv_rate))
+            "content" (tmpl.Exec "min_max_mean_std" (merge (dict "format" "bytes_rate") .recv_rate))
         ) }}
 
         {{ template "scenario_metric" (dict
             "name" "Network send rate (primary)"
             "description" "Rate of bytes sent on primary network interface"
-            "content" (tmpl.Exec "min_max_mean_std" (merge (dict "unit" "B/s") .send_rate))
+            "content" (tmpl.Exec "min_max_mean_std" (merge (dict "format" "bytes_rate") .send_rate))
         ) }}
 
         {{ with .bytes_recv }}
@@ -39,11 +39,11 @@ This template displays system-level performance metrics collected during the sce
                 "content" (print
                     (tmpl.Exec "scenario_metric_content_item" (dict
                         "name" "count"
-                        "content" (tmpl.Exec "scalar" (dict "value" .count "unit" "B"))
+                        "content" (tmpl.Exec "format_bytes" (dict "value" .count))
                     ))
                     (tmpl.Exec "scenario_metric_content_item" (dict
                         "name" "mean"
-                        "content" (tmpl.Exec "scalar" (dict "value" (printf "%.2f" .mean_rate_per_second) "unit" "B/s"))
+                        "content" (tmpl.Exec "format_bytes_rate" (dict "value" .mean_rate_per_second))
                     ))
                 )
             ) }}
@@ -56,11 +56,11 @@ This template displays system-level performance metrics collected during the sce
                 "content" (print
                     (tmpl.Exec "scenario_metric_content_item" (dict
                         "name" "count"
-                        "content" (tmpl.Exec "scalar" (dict "value" .count "unit" "B"))
+                        "content" (tmpl.Exec "format_bytes" (dict "value" .count))
                     ))
                     (tmpl.Exec "scenario_metric_content_item" (dict
                         "name" "mean"
-                        "content" (tmpl.Exec "scalar" (dict "value" (printf "%.2f" .mean_rate_per_second) "unit" "B/s"))
+                        "content" (tmpl.Exec "format_bytes_rate" (dict "value" .mean_rate_per_second))
                     ))
                 )
             ) }}
@@ -376,7 +376,7 @@ This template displays system-level performance metrics collected during the sce
         {{ template "scenario_metric" (dict
             "name" "Holochain process memory (PSS)"
             "description" "Proportional Set Size memory of Holochain process"
-            "content" (tmpl.Exec "min_max_mean_std" (merge (dict "unit" "B") .memory_pss))
+            "content" (tmpl.Exec "min_max_mean_std" (merge (dict "format" "bytes") .memory_pss))
         ) }}
 
         {{ template "scenario_metric" (dict

--- a/summary-visualiser/templates/helpers/mean.html.tmpl
+++ b/summary-visualiser/templates/helpers/mean.html.tmpl
@@ -4,11 +4,19 @@ Fields:
 
 * `mean` (scalar): The mean value.
 * `unit` (string, optional): The unit to display alongside the mean value.
+* `format` (string, optional): "bytes" or "bytes_rate" for auto-scaled byte formatting.
 */}}
 <span class="mean">
-    {{- template "scalar" (dict
-        "label" "mean "
-        "value" .mean
-        "unit" (index . "unit"))
-    -}}
+    {{- $format := (index . "format") -}}
+    {{- if (eq $format "bytes") -}}
+        {{ template "format_bytes" (dict "label" "mean " "value" .mean) }}
+    {{- else if (eq $format "bytes_rate") -}}
+        {{ template "format_bytes_rate" (dict "label" "mean " "value" .mean) }}
+    {{- else -}}
+        {{ template "scalar" (dict
+            "label" "mean "
+            "value" .mean
+            "unit" (index . "unit"))
+        }}
+    {{- end -}}
 </span>

--- a/summary-visualiser/templates/helpers/mean_std.html.tmpl
+++ b/summary-visualiser/templates/helpers/mean_std.html.tmpl
@@ -5,6 +5,7 @@ Fields:
 * `mean` (scalar): The mean value.
 * `std` (scalar): The standard deviation value.
 * `unit` (string, optional): The unit to display alongside the values.
+* `format` (string, optional): "bytes" or "bytes_rate" for auto-scaled byte formatting.
 */}}
 <span class="mean-std">
     {{ template "mean" . }}

--- a/summary-visualiser/templates/helpers/min_max_mean_std.html.tmpl
+++ b/summary-visualiser/templates/helpers/min_max_mean_std.html.tmpl
@@ -4,7 +4,10 @@ or min ≤ (mean ± std) ≤ max for RatioStats.
 
 GaugeStats fields: `p5`, `mean`, `std`, `p95`, `trend` (optional)
 RatioStats fields: `min`, `mean`, `std`, `max`
-Common optional: `unit` (string)
+Common optional: `unit` (string), `format` (string: "bytes" or "bytes_rate")
+
+When `format` is set to "bytes" or "bytes_rate", values are auto-scaled
+to human-readable units instead of using the raw `unit` string.
 
 Corresponding Rust types: `GaugeStats` or `RatioStats`
 */}}
@@ -17,13 +20,20 @@ Corresponding Rust types: `GaugeStats` or `RatioStats`
     {{ $low := test.Ternary (index . "p5") (index . "min") $is_gauge }}
     {{ $high := test.Ternary (index . "p95") (index . "max") $is_gauge }}
     {{ $unit := (index . "unit") }}
+    {{ $format := (index . "format") }}
 
     <span class="min-max-mean-std-min">
-        {{ template "scalar" (dict
-            "label" $low_label
-            "value" $low
-            "unit" $unit
-        ) }}
+        {{- if (eq $format "bytes") -}}
+            {{ template "format_bytes" (dict "label" $low_label "value" $low) }}
+        {{- else if (eq $format "bytes_rate") -}}
+            {{ template "format_bytes_rate" (dict "label" $low_label "value" $low) }}
+        {{- else -}}
+            {{ template "scalar" (dict
+                "label" $low_label
+                "value" $low
+                "unit" $unit
+            ) }}
+        {{- end -}}
     </span>
     {{ $lo_mean_symbol := test.Ternary "lt" "le" (lt $low .mean) }}
     <span class="divider divider-{{ $lo_mean_symbol }}">&{{ $lo_mean_symbol }};</span>
@@ -31,13 +41,22 @@ Corresponding Rust types: `GaugeStats` or `RatioStats`
     {{ $mean_hi_symbol := test.Ternary "lt" "le" (lt .mean $high) }}
     <span class="divider divider-{{ $mean_hi_symbol }}">&{{ $mean_hi_symbol }};</span>
     <span class="min-max-mean-std-max">
-        {{ template "scalar" (dict
-            "label" $high_label
-            "value" $high
-            "unit" $unit
-        ) }}
+        {{- if (eq $format "bytes") -}}
+            {{ template "format_bytes" (dict "label" $high_label "value" $high) }}
+        {{- else if (eq $format "bytes_rate") -}}
+            {{ template "format_bytes_rate" (dict "label" $high_label "value" $high) }}
+        {{- else -}}
+            {{ template "scalar" (dict
+                "label" $high_label
+                "value" $high
+                "unit" $unit
+            ) }}
+        {{- end -}}
     </span>
+    {{ $trend_unit := $unit }}
+    {{ if and (not $trend_unit) (eq $format "bytes") }}{{ $trend_unit = "B" }}{{ end }}
+    {{ if and (not $trend_unit) (eq $format "bytes_rate") }}{{ $trend_unit = "B/s" }}{{ end }}
     {{ with (index . "trend") }}
-        {{ template "trend_graph" (dict "data" .trend "mean" 0 "window_duration" .window_duration "unit" $unit) }}
+        {{ template "trend_graph" (dict "data" .trend "mean" 0 "window_duration" .window_duration "unit" $trend_unit) }}
     {{ end }}
 </div>

--- a/summary-visualiser/templates/helpers/std.html.tmpl
+++ b/summary-visualiser/templates/helpers/std.html.tmpl
@@ -4,14 +4,22 @@ Fields:
 
 * `std` (scalar): The standard deviation value.
 * `unit` (string, optional): The unit to display alongside the standard deviation value.
+* `format` (string, optional): "bytes" or "bytes_rate" for auto-scaled byte formatting.
 */}}
 <span class="std">
     {{/* These parentheses get wrapped in label spans so they're more subtle. */}}
     <span class="scalar-label">(</span>
-    {{- template "scalar" (dict
-        "label" "SD = "
-        "value" .std
-        "unit" (index . "unit"))
-    -}}
+    {{- $format := (index . "format") -}}
+    {{- if (eq $format "bytes") -}}
+        {{ template "format_bytes" (dict "label" "SD = " "value" .std) }}
+    {{- else if (eq $format "bytes_rate") -}}
+        {{ template "format_bytes_rate" (dict "label" "SD = " "value" .std) }}
+    {{- else -}}
+        {{ template "scalar" (dict
+            "label" "SD = "
+            "value" .std
+            "unit" (index . "unit"))
+        }}
+    {{- end -}}
     <span class="scalar-label">)</span>
 </span>


### PR DESCRIPTION
### Summary

added new gomplate helpers to fomrat bytes and bytes rate. Then I've added the template use to all of the bytes units in the current templates

closes #551

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human-readable byte formatting added for values and rates, with automatic unit scaling (B, KiB, MiB, GiB) and optional labels/suffixes.
  * Byte-rate formatting (e.g., "/s") supported alongside byte counts.

* **Style**
  * Metrics (network, memory, storage, trend units) consistently display scaled byte and byte-rate values with appropriate decimal precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->