### PR TITLE
feat(nomad): support arbitrary env vars in scenario vars.json files (#540)

### DIFF
--- a/nomad/README.md
+++ b/nomad/README.md
@@ -24,6 +24,31 @@ A simple Example:
 }
 ```
 
+An example with environment variables:
+
+```json
+{
+  "scenario_name": "write_get_agent_activity_volatile",
+  "duration": 900,
+  "assignments": [
+    {
+      "behaviour": "write",
+      "nodes": 2
+    },
+    {
+      "behaviour": "get_agent_activity_volatile",
+      "nodes": 8
+    }
+  ],
+  "env": {
+    "CONDUCTOR_ON_MIN_S": "10",
+    "CONDUCTOR_ON_MAX_S": "30",
+    "CONDUCTOR_OFF_MIN_S": "2",
+    "CONDUCTOR_OFF_MAX_S": "10"
+  }
+}
+```
+
 The following variables are available:
 
 - `description`: A human-readable description of what the job does. (_optional_, not used at runtime — serves as documentation for the vars file)
@@ -36,8 +61,10 @@ The following variables are available:
 - `connection_string`: The connection string to the Holochain conductor. (_optional_, defaults to `ws://localhost:8888`)
 - `run_id`: The ID of the run to distinguish it from other runs. (_optional_, defaults to `null`)
 - `reporter`: The reporter type to use. (_optional_, defaults to `influx-file`)
-- `min_agents`: The minimum number of agents each agent will wait for, including itself, before running some
-  scenarios. (_optional_, defaults to `2`)
+- `env`: An object of arbitrary key-value pairs to set as environment variables for the scenario run. (_optional_, defaults to `{}`)
+  Each key-value pair is injected into the Nomad task's `env` block. This can be used to configure scenario-specific
+  behavior. For example, `MIN_AGENTS` controls the minimum number of agents each agent will wait for before running.
+  See individual scenario documentation for available environment variables.
 
 ## Generate Nomad Jobs
 

--- a/nomad/job-variants/canonical/vars/remote_signals.json
+++ b/nomad/job-variants/canonical/vars/remote_signals.json
@@ -8,5 +8,9 @@
       "nodes": 5,
       "agents": 2
     }
-  ]
+  ],
+  "env": {
+    "SIGNAL_INTERVAL_MS": "1000",
+    "RESPONSE_TIMEOUT_MS": "20000"
+  }
 }

--- a/nomad/job-variants/canonical/vars/unyt_chain_transaction.json
+++ b/nomad/job-variants/canonical/vars/unyt_chain_transaction.json
@@ -2,7 +2,6 @@
   "description": "1 progenitor initialises the network; 32 spend and 32 smart_agreements agents run concurrent transactions. Target 50/50 spend/smart_agreements; actual 50/50 at 64 transaction agents (65 nodes total).",
   "scenario_name": "unyt_chain_transaction",
   "duration": 900,
-  "min_agents": 65,
   "assignments": [
     {
       "behaviour": "initiate"
@@ -15,5 +14,9 @@
       "behaviour": "smart_agreements",
       "nodes": 32
     }
-  ]
+  ],
+  "env": {
+    "MIN_AGENTS": "65",
+    "UNYT_NUMBER_OF_LINKS_TO_PROCESS": "10"
+  }
 }

--- a/nomad/job-variants/canonical/vars/unyt_chain_transaction_zero_arc.json
+++ b/nomad/job-variants/canonical/vars/unyt_chain_transaction_zero_arc.json
@@ -1,7 +1,6 @@
 {
   "scenario_name": "unyt_chain_transaction_zero_arc",
   "duration": 900,
-  "min_agents": 7,
   "assignments": [
     {
       "behaviour": "initiate"
@@ -20,5 +19,9 @@
     {
       "behaviour": "zero_observer"
     }
-  ]
+  ],
+  "env": {
+    "MIN_AGENTS": "7",
+    "UNYT_NUMBER_OF_LINKS_TO_PROCESS": "10"
+  }
 }

--- a/nomad/job-variants/canonical/vars/write_get_agent_activity_volatile.json
+++ b/nomad/job-variants/canonical/vars/write_get_agent_activity_volatile.json
@@ -11,5 +11,11 @@
       "behaviour": "get_agent_activity_volatile",
       "nodes": 46
     }
-  ]
+  ],
+  "env": {
+    "CONDUCTOR_ON_MIN_S": "10",
+    "CONDUCTOR_ON_MAX_S": "30",
+    "CONDUCTOR_OFF_MIN_S": "2",
+    "CONDUCTOR_OFF_MAX_S": "10"
+  }
 }

--- a/nomad/job-variants/demo/vars/remote_signals.json
+++ b/nomad/job-variants/demo/vars/remote_signals.json
@@ -6,5 +6,9 @@
       "behaviour": "default",
       "agents": 2
     }
-  ]
+  ],
+  "env": {
+    "SIGNAL_INTERVAL_MS": "1000",
+    "RESPONSE_TIMEOUT_MS": "20000"
+  }
 }

--- a/nomad/job-variants/demo/vars/unyt_chain_transaction.json
+++ b/nomad/job-variants/demo/vars/unyt_chain_transaction.json
@@ -1,7 +1,6 @@
 {
   "scenario_name": "unyt_chain_transaction",
   "duration": 300,
-  "min_agents": 5,
   "assignments": [
     {
       "behaviour": "initiate"
@@ -14,5 +13,9 @@
       "behaviour": "smart_agreements",
       "nodes": 2
     }
-  ]
+  ],
+  "env": {
+    "MIN_AGENTS": "5",
+    "UNYT_NUMBER_OF_LINKS_TO_PROCESS": "10"
+  }
 }

--- a/nomad/job-variants/demo/vars/unyt_chain_transaction_zero_arc.json
+++ b/nomad/job-variants/demo/vars/unyt_chain_transaction_zero_arc.json
@@ -1,7 +1,6 @@
 {
   "scenario_name": "unyt_chain_transaction_zero_arc",
   "duration": 300,
-  "min_agents": 7,
   "assignments": [
     {
       "behaviour": "initiate"
@@ -20,5 +19,9 @@
     {
       "behaviour": "zero_observer"
     }
-  ]
+  ],
+  "env": {
+    "MIN_AGENTS": "7",
+    "UNYT_NUMBER_OF_LINKS_TO_PROCESS": "10"
+  }
 }

--- a/nomad/job-variants/demo/vars/write_get_agent_activity_volatile.json
+++ b/nomad/job-variants/demo/vars/write_get_agent_activity_volatile.json
@@ -10,5 +10,11 @@
       "behaviour": "get_agent_activity_volatile",
       "nodes": 8
     }
-  ]
+  ],
+  "env": {
+    "CONDUCTOR_ON_MIN_S": "10",
+    "CONDUCTOR_ON_MAX_S": "30",
+    "CONDUCTOR_OFF_MIN_S": "2",
+    "CONDUCTOR_OFF_MAX_S": "10"
+  }
 }

--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -141,11 +141,13 @@ job "{{ (ds "vars").scenario_name }}" {
           RUST_LOG                    = "info"
           HOME                        = "${NOMAD_TASK_DIR}"
           WT_METRICS_DIR              = "${NOMAD_ALLOC_DIR}/data/telegraf/metrics"
-          MIN_AGENTS                  = "{{ index (ds "vars") "min_agents" | default 2 }}"
           RUN_SUMMARY_PATH            = "${NOMAD_ALLOC_DIR}/run_summary.jsonl"
           WT_HOLOCHAIN_PATH           = var.holochain_bin_url == null ? "holochain" : "${NOMAD_ALLOC_DIR}/holochain"
           UNYT_DURABLE_OBJECTS_URL    = secret.job_secrets.UNYT_DURABLE_OBJECTS_URL
           UNYT_DURABLE_OBJECTS_SECRET = secret.job_secrets.UNYT_DURABLE_OBJECTS_SECRET
+          {{- range $key, $value := (index (ds "vars") "env" | default (coll.Dict)) }}
+          {{ $key }} = "{{ $value }}"
+          {{- end }}
         }
 
         config {


### PR DESCRIPTION
### Summary

Replace the hardcoded MIN_AGENTS template variable with a generic env
object in vars.json files. Each key-value pair in the env object is
injected into the Nomad task's env block via a gomplate range loop.

- Add env object support to gomplate template (run_scenario.tpl.hcl)
- Migrate unyt_chain_transaction: move min_agents to env.MIN_AGENTS,
  add NUMBER_OF_LINKS_TO_PROCESS with default value
- Add env vars to write_get_agent_activity_volatile (CONDUCTOR_* vars)
- Add env object to validation_receipts (empty, supports NO_VALIDATION_COMPLETE)
- Add env vars to remote_signals (SIGNAL_INTERVAL_MS, RESPONSE_TIMEOUT_MS)
- Update README documentation with env object syntax and example

Closes #540

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration syntax to use environment variables for scenario-specific settings, replacing the previous min_agents parameter with a generalized env object.

* **Chores**
  * Migrated job configuration from explicit parameters to environment variable-based configuration across all job variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->