### PR TITLE
test: temporarily disable `say_something_to_other_chatter` because it's hanging in ci

### DIFF
--- a/bindings/kitsune_client/src/lib.rs
+++ b/bindings/kitsune_client/src/lib.rs
@@ -227,6 +227,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "this test is hanging on CI"]
     async fn say_something_to_other_chatter() {
         let _ = env_logger::builder().is_test(true).try_init();
         if CryptoProvider::get_default().is_none() {


### PR DESCRIPTION
### Summary

closes #578

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Configured specific tests to be skipped in CI pipelines unless explicitly executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->