### PR TITLE
feat(nomad): get `peer_end_count` by summing `peer_end_count` from run summaries inside of allocations by their run_id

### DIFF
--- a/nomad/scripts/ci_allocs.sh
+++ b/nomad/scripts/ci_allocs.sh
@@ -71,6 +71,14 @@ function generate_run_summary() {
         return 1
     fi
 
+    # Fetch peer_end_count per run_id by querying each allocation's run_summary.jsonl via Nomad API
+    declare -A peer_end_count_by_run
+    while IFS=',' read -r _job_name _scenario_name alloc_id _run_id _started_at _duration _peer_count _behaviours; do
+        local this_alloc_peer_end_count
+        this_alloc_peer_end_count=$(fetch_peer_end_count "$alloc_id" "$_peer_count")
+        peer_end_count_by_run["$_run_id"]="$(( ${peer_end_count_by_run["$_run_id"]:-0} + this_alloc_peer_end_count ))"
+    done < "$allocs_csv_file"
+
     touch "$run_summary_file"
 
     local wind_tunnel_version
@@ -89,12 +97,14 @@ function generate_run_summary() {
     local behaviours
 
     while IFS=',' read -r _job_name scenario_name alloc_id run_id started_at duration peer_count behaviours; do
-        echo "Processing line: $run_id / $scenario_name / $alloc_id / $started_at / $duration / $peer_count / $behaviours"
+        local peer_end_count="${peer_end_count_by_run["$run_id"]:-$peer_count}"
+        echo "Processing line: $run_id / $scenario_name / $alloc_id / $started_at / $duration / $peer_count / $peer_end_count / $behaviours"
         jq -cn \
           --arg run_id "$run_id" \
           --arg scenario_name "$scenario_name" \
           --argjson started_at "$started_at" \
           --argjson peer_count "$peer_count" \
+          --argjson peer_end_count "$peer_end_count" \
           --arg behaviours "${behaviours:-}" \
           --arg wind_tunnel_version "$wind_tunnel_version" \
           --argjson holochain_build_info "$holochain_build_info" \
@@ -108,7 +118,7 @@ function generate_run_summary() {
                 duration: $duration,
                 assigned_behaviours: (reduce $bs[] as $b ({}; .[$b] += 1)),
                 peer_count: $peer_count,
-                peer_end_count: $peer_count,
+                peer_end_count: $peer_end_count,
                 env: {},
                 build_info: { info_type: "holochain", info: $holochain_build_info },
                 wind_tunnel_version: $wind_tunnel_version
@@ -135,6 +145,20 @@ function holochain_build_info() {
     local build_info
     build_info="$($holochain_bin --build-info 2>/dev/null || echo "null")"
     echo "$build_info"
+}
+
+function fetch_peer_end_count() {
+    local alloc_id="$1"
+    local fallback_peer_count="$2"
+    local result
+    result=$(nomad alloc fs "$alloc_id" alloc/run_summary.jsonl 2>/dev/null | jq --slurp 'last | .peer_end_count') || result=""
+    if [[ -z "$result" || "$result" == "null" ]]; then
+        echo "Warning: could not fetch peer_end_count for alloc $alloc_id, falling back to configured peer_count ($fallback_peer_count)" >&2
+        echo "$fallback_peer_count"
+        return
+    fi
+    echo "Fetched peer_end_count for alloc $alloc_id: $result" >&2
+    echo "$result"
 }
 
 cmd=$1


### PR DESCRIPTION
## Summary

When running scenarios via Nomad, the `peer_end_count` in the generated `run_summary.jsonl` was always set to the configured `peer_count`, ignoring agents that may have dropped during the run. This PR fixes that by fetching each allocation's `run_summary.jsonl` via the Nomad API, reading the actual `peer_end_count`, and summing them per `run_id`.

### Changes

- Added `fetch_peer_end_count` function that reads `peer_end_count` from an allocation's `run_summary.jsonl` via `nomad alloc fs`, with a fallback to the configured `peer_count` if the file is unavailable.
- Before generating the combined run summary, iterate over all allocations to build a `peer_end_count_by_run` map keyed by `run_id`.
- Use the summed `peer_end_count` instead of hardcoding it to `peer_count` in the jq template.

closes #504

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI allocation data collection to aggregate final peer counts per run, updating exported run summaries to use aggregated values with fallbacks and emitting warnings when allocation-level data is missing, enhancing accuracy of run-level metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->