### PR TITLE
fix(nomad): handle "No running jobs" text output from nomad job status

### DIFF
--- a/nomad/scripts/count_eligible_nodes.sh
+++ b/nomad/scripts/count_eligible_nodes.sh
@@ -62,12 +62,32 @@ if [[ "$ELIGIBLE_ONLY" == "true" ]]; then
 fi
 
 # 'nomad job status -namespace * -json' returns the full allocation list across all namespaces.
-# Filter immediately to "running" NodeIDs to avoid holding the large response (which includes
-# TaskStates/Events per allocation).
-busy_json=$("$NOMAD" job status -namespace '*' -json 2>&1 | jq '[.[].Allocations // [] | .[]] | map(select(.ClientStatus == "running") | .NodeID) | unique' 2>&1) || {
-  echo "ERROR: 'nomad job status -namespace * -json' failed or returned invalid JSON: $busy_json" >&2
+# The response is buffered so we can handle the "No running jobs" plain-text fallback before
+# passing valid JSON to jq for filtering.
+nomad_jobs_stderr=$(mktemp)
+jobs_json=$("$NOMAD" job status -namespace '*' -json 2>"$nomad_jobs_stderr") || {
+  echo "ERROR: 'nomad job status -namespace * -json' failed: $jobs_json" >&2
+  if [[ -s "$nomad_jobs_stderr" ]]; then
+    echo "Nomad stderr: $(cat "$nomad_jobs_stderr")" >&2
+  fi
+  rm -f "$nomad_jobs_stderr"
   exit 1
 }
+if [[ -s "$nomad_jobs_stderr" ]]; then
+  echo "WARNING (nomad job status stderr): $(cat "$nomad_jobs_stderr")" >&2
+fi
+rm -f "$nomad_jobs_stderr"
+
+# When there are no running jobs, Nomad outputs "No running jobs" instead of JSON.
+if [[ "$jobs_json" == "No running jobs" ]]; then
+  busy_json='[]'
+elif echo "$jobs_json" | jq -e . >/dev/null 2>&1; then
+  busy_json=$(<<< "$jobs_json" jq '[.[].Allocations // [] | .[]] | map(select(.ClientStatus == "running") | .NodeID) | unique')
+else
+  echo "ERROR: 'nomad job status -namespace * -json' did not return valid JSON." >&2
+  echo "First 500 chars of output: ${jobs_json:0:500}" >&2
+  exit 1
+fi
 
 echo "There are currently $(<<< "$busy_json" jq length) nodes with running allocations" >&2
 


### PR DESCRIPTION
Nomad ignores the -json flag when there are no jobs and returns plain
text instead of an empty JSON array, which caused jq parse failures in
count_eligible_nodes.sh. Treat this case as zero busy nodes.

### Summary



### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging and warnings for command failures and invalid outputs.
  * Correct handling of cases with no running jobs and more accurate running-allocation counts.

* **Chores**
  * Made data collection and validation more robust to prevent silent failures during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->