### PR TITLE
ci: log summariser run RAM usage with `time -v`

### DIFF
--- a/.github/workflows/nomad-common.yaml
+++ b/.github/workflows/nomad-common.yaml
@@ -328,7 +328,9 @@ jobs:
           INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           RUST_LOG: info,holochain_summariser=debug
           IGNORE_SUMMARY_ERRORS: ${{ inputs.ignore-summary-errors }}
-        run: nix develop --command cargo run --release --bin holochain-summariser
+        run: |
+          nix develop --command cargo build --release --bin holochain-summariser
+          nix develop --command /usr/bin/time -v ./target/release/holochain-summariser
 
       - name: Generate summary id for artifacts
         id: generate-summary-id


### PR DESCRIPTION
### Summary

- Split the summariser `cargo run` step into separate build and run steps so that `/usr/bin/time -v` can wrap only the execution, logging peak RSS and other resource usage metrics for the summariser run.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_