### PR TITLE
Feat/retry scenario download

### DIFF
--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -104,6 +104,13 @@ job "{{ (ds "vars").scenario_name }}" {
         labels   = ["download_holochain_bin"]
 
         content {
+          restart {
+            attempts = 5
+            interval = "1m"
+            delay    = "8s"
+            mode     = "fail"
+          }
+
           lifecycle {
             hook = "prestart"
             sidecar = false
@@ -125,17 +132,40 @@ job "{{ (ds "vars").scenario_name }}" {
         }
       }
 
-      task "run_scenario" {
-        driver = "raw_exec"
+      dynamic "task" {
+        // Only download the scenario binary if `var.scenario_url` is not a valid local path.
+        for_each = fileexists(abspath(var.scenario_url)) ? [] : [var.scenario_url]
+        labels   = ["download_scenario_bin"]
 
-        dynamic "artifact" {
-          // Download the scenario from the URL if it is not a valid local path.
-          for_each = fileexists(abspath(var.scenario_url)) ? [] : [var.scenario_url]
+        content {
+          restart {
+            attempts = 5
+            interval = "1m"
+            delay    = "8s"
+            mode     = "fail"
+          }
 
-          content {
-            source = var.scenario_url
+          lifecycle {
+            hook = "prestart"
+            sidecar = false
+          }
+
+          driver = "raw_exec"
+
+          artifact {
+            source      = var.scenario_url
+            destination = "${NOMAD_ALLOC_DIR}/scenario"
+          }
+
+          config {
+            command = "chmod"
+            args    = ["+x", "${NOMAD_ALLOC_DIR}/scenario/bin/{{ (ds "vars").scenario_name }}"]
           }
         }
+      }
+
+      task "run_scenario" {
+        driver = "raw_exec"
 
         env {
           RUST_LOG                    = "info"
@@ -151,8 +181,8 @@ job "{{ (ds "vars").scenario_name }}" {
         }
 
         config {
-          // If `var.scenario_url` is a valid local path then run that. Otherwise run the scenario downloaded by the `artifact` block.
-          command = fileexists(abspath(var.scenario_url)) ? abspath(var.scenario_url) : "${NOMAD_TASK_DIR}/bin/{{ (ds "vars").scenario_name }}"
+          // If `var.scenario_url` is a valid local path then run that. Otherwise run the scenario downloaded by the `download_scenario_bin` task.
+          command = fileexists(abspath(var.scenario_url)) ? abspath(var.scenario_url) : "${NOMAD_ALLOC_DIR}/scenario/bin/{{ (ds "vars").scenario_name }}"
           // The `compact` function removes empty strings and `null` items from the list.
           args = compact([
             "--duration=${var.duration}",


### PR DESCRIPTION
### Summary
Resolves #479 
- Retry `download_holochain_bin` task
- Split out downloading of scenario binary into separate task `download_scenario_bin`
- Retry `download_scenario_bin` task


### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry for scenario downloads (5 attempts, 1-minute intervals, short delay) to improve reliability.

* **Refactor**
  * Separate download step for scenario binaries; downloaded binaries are placed in the allocation directory and explicitly made executable.
  * Run step updated to use the new downloaded binary location when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->