### PR TITLE
Feat/render windowed values as line for window duration

### DIFF
--- a/summary-visualiser/assets/wind_tunnel.js
+++ b/summary-visualiser/assets/wind_tunnel.js
@@ -44,6 +44,13 @@ function getTrendGraphMargin(trendData, yUnit) {
     };
 }
 
+function getTrendBucketPoints(trendData) {
+    return trendData.flatMap((value, index) => [
+        { x: index, y: value },
+        { x: index + 1, y: value },
+    ]);
+}
+
 function renderTrendGraph(entry, plotWidth, margin) {
     const {
         svgElement,
@@ -54,6 +61,7 @@ function renderTrendGraph(entry, plotWidth, margin) {
     } = entry;
     const width = Math.max(1, plotWidth);
     const height = 120;
+    const bucketPoints = getTrendBucketPoints(trendData);
     const maxVal = d3.max(trendData);
     const maxYLabel = `${maxVal}${yUnit || ""}`;
     const minYLabel = `0${yUnit || ""}`;
@@ -70,9 +78,9 @@ function renderTrendGraph(entry, plotWidth, margin) {
     const svg = root.append("g")
         .attr("transform", `translate(${margin.left},${margin.top})`);
 
-    // Map time window values to the x range of the graph.
+    // Map bucket boundaries to the x range of the graph.
     const x = d3.scaleLinear()
-        .domain([0, trendData.length - 1])
+        .domain([0, trendData.length])
         .range([0, width]);
 
     // Map data point values to the y range of the graph.
@@ -82,20 +90,20 @@ function renderTrendGraph(entry, plotWidth, margin) {
 
     // The trend line.
     const line = d3.line()
-        .x((d, i) => x(i))
-        .y(d => y(d));
+        .x(d => x(d.x))
+        .y(d => y(d.y));
     svg.append("path")
-        .datum(trendData)
+        .datum(bucketPoints)
         .attr("class", "trend-line")
         .attr("d", line);
 
     // The area under the trend line.
     const area = d3.area()
-        .x((d, i) => x(i))
+        .x(d => x(d.x))
         .y0(height)
-        .y1(d => y(d));
+        .y1(d => y(d.y));
     svg.append("path")
-        .datum(trendData)
+        .datum(bucketPoints)
         .attr("class", "trend-area")
         .attr("d", area);
 
@@ -127,7 +135,7 @@ function renderTrendGraph(entry, plotWidth, margin) {
         .text(minYLabel);
 
     // X-axis labels -- 0 seconds at the start,
-    // and the number of data points × the time window duration at the end.
+    // and the number of buckets × the time window duration at the end.
     const parsedDuration = parseWindowDuration(windowDuration);
     const totalDuration = parsedDuration.durationValue * trendData.length;
 


### PR DESCRIPTION
### Summary
Follow-up to #598 

The charts in the summary visualizer represent windowed data, but are displayed as a single point at the end of the window. This PR modifies them to display as a line across the window.

For example:
<img width="1181" height="385" alt="line-across-window" src="https://github.com/user-attachments/assets/4e57eb03-1d95-4c0e-9172-40f1bae1e6ec" />

I'm not sure if this is the right approach, or if there is a standard way to represent this data, but it seems like the most accurate representation.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced trend graph rendering with improved dynamic scaling and coordinated multi-graph layout.
  * Improved duration parsing for time window specifications.

* **Bug Fixes**
  * Corrected memory growth rate and disk throughput unit display from "MB/s" to "MiB/s" for accuracy.

* **Style**
  * Refined metric widget layouts and spacing for improved visual consistency.
  * Updated responsive design for better metric display across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->