### PR TITLE
Update INFLUX_TOKEN Nomad var

### DIFF
--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -185,7 +185,7 @@ job "{{ (ds "vars").scenario_name }}" {
             RUN_SUMMARY_PATH     = "${NOMAD_ALLOC_DIR}/run_summary.jsonl"
             INFLUX_HOST          = "https://ifdb.holochain.org"
             INFLUX_BUCKET        = "windtunnel"
-            INFLUX_TOKEN         = secret.job_secrets.INFLUX_WINDTUNNEL_BUCKET_TOKEN
+            INFLUX_TOKEN         = secret.job_secrets.INFLUX_TOKEN
           }
 
           driver = "raw_exec"


### PR DESCRIPTION
### Summary

After re-deploying the Nomad Server it sets the influx token Nomad var as `INFLUX_TOKEN` but the value `INFLUX_WINDTUNNEL_BUCKET_TOKEN` was being used which was set manually in Nomad and supposed to be temporary. I didn't change it in the automated Nomad server deploy because I thought we needed to update the certificate here anyways and they could be changed at the same time. I was wrong about the cert but this now needs changing.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment configuration for metrics upload so the service uses the correct runtime credential for Influx authentication, restoring reliable metrics submission and dashboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->