### PR TITLE
ci: set nomad CI concurrency group to a shared name to prevent concurrent run between canonical and demo workflows

### DIFF
--- a/.github/workflows/nomad-canonical.yaml
+++ b/.github/workflows/nomad-canonical.yaml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron: "0 0 * * 4" # Run Nomad workflow at 00:00 on Thursdays
 
-concurrency:
-  group: nomad-canonical
-  cancel-in-progress: false
-
 jobs:
   nomad-canonical:
     uses: ./.github/workflows/nomad-common.yaml

--- a/.github/workflows/nomad-common.yaml
+++ b/.github/workflows/nomad-common.yaml
@@ -1,5 +1,9 @@
 name: "Run Nomad Scenario"
 
+concurrency:
+  group: nomad
+  cancel-in-progress: false
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/nomad-demo.yaml
+++ b/.github/workflows/nomad-demo.yaml
@@ -14,10 +14,6 @@ on:
       - ".github/workflows/nomad*.yaml"
       - ".github/actions/nomad/action.yaml"
 
-concurrency:
-  group: nomad-demo
-  cancel-in-progress: false
-
 jobs:
   nomad-demo:
     uses: ./.github/workflows/nomad-common.yaml


### PR DESCRIPTION
### Summary

closes #606

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to optimize build execution behavior through centralized concurrency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->