### PR TITLE
Only rebuild scenarios on a relevant file change

### DIFF
--- a/.github/actions/nomad/action.yaml
+++ b/.github/actions/nomad/action.yaml
@@ -84,12 +84,30 @@ runs:
       run: |
         nix run .#generate-nomad-jobs -- --job-name ${{ inputs.job-name }} --job-variant-path ${{ inputs.nomad-job-variant-directory }}
 
+    - name: Check if need to rebuild the scenario
+      id: needs-rebuild
+      uses: tj-actions/changed-files@v47
+      with:
+        files: |
+          bindings/**
+          Cargo.lock
+          dnas/${{ steps.read-nomad-vars.outputs.scenario_name }}/**
+          framework/**
+          happ_builder/**
+          nix/modules/**
+          rust-toolchain.toml
+          scenarios/${{ steps.read-nomad-vars.outputs.scenario_name }}/**
+          scenarios_common/**
+          zomes/**
+
     - name: Build scenario
+      if: steps.needs-rebuild.outputs.any_changed == 'true'
       shell: bash
       run: nix build .#packages.x86_64-linux.${{ steps.read-nomad-vars.outputs.scenario_name }}
 
     - name: Upload scenario to bucket
       id: upload-scenario
+      if: steps.needs-rebuild.outputs.any_changed == 'true'
       shell: bash
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.hetzner-buckets-access }}
@@ -103,6 +121,24 @@ runs:
 
         echo "scenario_download_url=${AWS_ENDPOINT_URL}/${OUT_PATH}" >> "$GITHUB_OUTPUT"
         echo "Uploaded run scenario artifact to ${AWS_ENDPOINT_URL}/${OUT_PATH}" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Get scenario URL
+      id: get-scenario-url
+      shell: bash
+      env:
+        NEEDS_REBUILD: ${{ steps.needs-rebuild.outputs.any_changed }}
+        NEW_SCENARIO_URL: ${{ steps.upload-scenario.outputs.scenario_download_url }}
+        SCENARIO_NAME: ${{ steps.read-nomad-vars.outputs.scenario_name }}
+        GH_TOKEN: ${{ github.token }}
+      run: |-
+        if [[ "$NEEDS_REBUILD" == 'true' ]]; then
+          echo "Using newly built scenario from ${NEW_SCENARIO_URL}"
+          echo "scenario_download_url=${NEW_SCENARIO_URL}" >> "$GITHUB_OUTPUT"
+        else
+          TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          echo "Using latest release of scenario from tag '$TAG'"
+          echo "scenario_download_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${SCENARIO_NAME}.zip" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Wait For Minimum Free Nodes
       shell: bash
@@ -144,7 +180,7 @@ runs:
         NOMAD_ADDR: https://nomad-server-01.holochain.org:4646
         NOMAD_CACERT: "${{ github.workspace }}/nomad/server-ca-cert.pem"
         NOMAD_TOKEN: ${{ inputs.nomad-access-token }}
-        NOMAD_VAR_scenario_url: ${{ steps.upload-scenario.outputs.scenario_download_url }}
+        NOMAD_VAR_scenario_url: ${{ steps.get-scenario-url.outputs.scenario_download_url }}
         NOMAD_VAR_run_id: ${{ env.RUN_ID }}
         NOMAD_VAR_holochain_bin_url: ${{ inputs.holochain-bin-url }}
         NOMAD_VAR_include_threefold_node_pool: ${{ inputs.include-threefold-node-pool }}
@@ -177,7 +213,7 @@ runs:
         NOMAD_ADDR: https://nomad-server-01.holochain.org:4646
         NOMAD_CACERT: "${{ github.workspace }}/nomad/server-ca-cert.pem"
         NOMAD_TOKEN: ${{ inputs.nomad-access-token }}
-        NOMAD_VAR_scenario_url: ${{ steps.upload-scenario.outputs.scenario_download_url }}
+        NOMAD_VAR_scenario_url: ${{ steps.get-scenario-url.outputs.scenario_download_url }}
         NOMAD_VAR_run_id: ${{ env.RUN_ID }}
         NOMAD_VAR_holochain_bin_url: ${{ inputs.holochain-bin-url }}
         NOMAD_VAR_include_threefold_node_pool: ${{ inputs.include-threefold-node-pool }}

--- a/.github/actions/nomad/action.yaml
+++ b/.github/actions/nomad/action.yaml
@@ -140,7 +140,14 @@ runs:
           echo "Using newly built scenario from ${NEW_SCENARIO_URL}"
           echo "scenario_download_url=${NEW_SCENARIO_URL}" >> "$GITHUB_OUTPUT"
         else
-          TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          TAG=$(gh api "/repos/${GITHUB_REPOSITORY}/releases?per_page=10" \
+            | jq -r --arg name "${SCENARIO_NAME}.zip" \
+              '.[] | select(any(.assets[]; .name == $name)) | .tag_name' \
+            | head -1)
+          if [[ -z "$TAG" ]]; then
+            echo "::error::Could not find a release containing ${SCENARIO_NAME}.zip"
+            exit 1
+          fi
           echo "Using latest release of scenario from tag '$TAG'"
           echo "scenario_download_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${SCENARIO_NAME}.zip" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/actions/nomad/action.yaml
+++ b/.github/actions/nomad/action.yaml
@@ -28,6 +28,10 @@ inputs:
     required: true
   cachix-auth-token:
     required: true
+  force-rebuild:
+    description: "Force a rebuild of the scenario even if no relevant files have changed"
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -101,13 +105,13 @@ runs:
           zomes/**
 
     - name: Build scenario
-      if: steps.needs-rebuild.outputs.any_changed == 'true'
+      if: steps.needs-rebuild.outputs.any_changed == 'true' || inputs.force-rebuild == 'true'
       shell: bash
       run: nix build .#packages.x86_64-linux.${{ steps.read-nomad-vars.outputs.scenario_name }}
 
     - name: Upload scenario to bucket
       id: upload-scenario
-      if: steps.needs-rebuild.outputs.any_changed == 'true'
+      if: steps.needs-rebuild.outputs.any_changed == 'true' || inputs.force-rebuild == 'true'
       shell: bash
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.hetzner-buckets-access }}
@@ -127,11 +131,12 @@ runs:
       shell: bash
       env:
         NEEDS_REBUILD: ${{ steps.needs-rebuild.outputs.any_changed }}
+        FORCE_REBUILD: ${{ inputs.force-rebuild }}
         NEW_SCENARIO_URL: ${{ steps.upload-scenario.outputs.scenario_download_url }}
         SCENARIO_NAME: ${{ steps.read-nomad-vars.outputs.scenario_name }}
         GH_TOKEN: ${{ github.token }}
       run: |-
-        if [[ "$NEEDS_REBUILD" == 'true' ]]; then
+        if [[ "$NEEDS_REBUILD" == 'true' || "$FORCE_REBUILD" == 'true' ]]; then
           echo "Using newly built scenario from ${NEW_SCENARIO_URL}"
           echo "scenario_download_url=${NEW_SCENARIO_URL}" >> "$GITHUB_OUTPUT"
         else

--- a/.github/actions/nomad/action.yaml
+++ b/.github/actions/nomad/action.yaml
@@ -104,14 +104,35 @@ runs:
           scenarios_common/**
           zomes/**
 
+    - name: Check if release exists
+      id: check-release
+      if: steps.needs-rebuild.outputs.any_changed != 'true' && inputs.force-rebuild != 'true'
+      shell: bash
+      env:
+        SCENARIO_NAME: ${{ steps.read-nomad-vars.outputs.scenario_name }}
+        GH_TOKEN: ${{ github.token }}
+      run: |-
+        TAG=$(gh api "/repos/${GITHUB_REPOSITORY}/releases?per_page=10" \
+          | jq -r --arg name "${SCENARIO_NAME}.zip" \
+            '.[] | select(any(.assets[]; .name == $name)) | .tag_name' \
+          | head -1)
+        if [[ -z "$TAG" ]]; then
+          echo "::warning::No release found containing ${SCENARIO_NAME}.zip, falling back to a rebuild"
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "Found release tag '$TAG' containing ${SCENARIO_NAME}.zip"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${SCENARIO_NAME}.zip" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Build scenario
-      if: steps.needs-rebuild.outputs.any_changed == 'true' || inputs.force-rebuild == 'true'
+      if: steps.needs-rebuild.outputs.any_changed == 'true' || inputs.force-rebuild == 'true' || steps.check-release.outputs.found == 'false'
       shell: bash
       run: nix build .#packages.x86_64-linux.${{ steps.read-nomad-vars.outputs.scenario_name }}
 
     - name: Upload scenario to bucket
       id: upload-scenario
-      if: steps.needs-rebuild.outputs.any_changed == 'true' || inputs.force-rebuild == 'true'
+      if: steps.needs-rebuild.outputs.any_changed == 'true' || inputs.force-rebuild == 'true' || steps.check-release.outputs.found == 'false'
       shell: bash
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.hetzner-buckets-access }}
@@ -130,26 +151,15 @@ runs:
       id: get-scenario-url
       shell: bash
       env:
-        NEEDS_REBUILD: ${{ steps.needs-rebuild.outputs.any_changed }}
-        FORCE_REBUILD: ${{ inputs.force-rebuild }}
         NEW_SCENARIO_URL: ${{ steps.upload-scenario.outputs.scenario_download_url }}
-        SCENARIO_NAME: ${{ steps.read-nomad-vars.outputs.scenario_name }}
-        GH_TOKEN: ${{ github.token }}
+        RELEASE_URL: ${{ steps.check-release.outputs.url }}
       run: |-
-        if [[ "$NEEDS_REBUILD" == 'true' || "$FORCE_REBUILD" == 'true' ]]; then
+        if [[ -n "$NEW_SCENARIO_URL" ]]; then
           echo "Using newly built scenario from ${NEW_SCENARIO_URL}"
           echo "scenario_download_url=${NEW_SCENARIO_URL}" >> "$GITHUB_OUTPUT"
         else
-          TAG=$(gh api "/repos/${GITHUB_REPOSITORY}/releases?per_page=10" \
-            | jq -r --arg name "${SCENARIO_NAME}.zip" \
-              '.[] | select(any(.assets[]; .name == $name)) | .tag_name' \
-            | head -1)
-          if [[ -z "$TAG" ]]; then
-            echo "::error::Could not find a release containing ${SCENARIO_NAME}.zip"
-            exit 1
-          fi
-          echo "Using latest release of scenario from tag '$TAG'"
-          echo "scenario_download_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${SCENARIO_NAME}.zip" >> "$GITHUB_OUTPUT"
+          echo "Using latest release of scenario from ${RELEASE_URL}"
+          echo "scenario_download_url=${RELEASE_URL}" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Wait For Minimum Free Nodes

--- a/.github/workflows/nomad-canonical-scaled.yaml
+++ b/.github/workflows/nomad-canonical-scaled.yaml
@@ -2,6 +2,12 @@ name: "Run canonical scaled performance tests on Nomad cluster and Threefold nod
 
 on:
   workflow_dispatch:
+    inputs:
+      rebuild-all-scenarios:
+        description: "Force a rebuild of all scenarios even if no relevant files have changed"
+        type: boolean
+        required: false
+        default: false
   schedule:
     - cron: "0 0 * * 5" # Run Nomad workflow at 00:00 on Fridays
 
@@ -124,6 +130,7 @@ jobs:
           holochain-bin-url: https://github.com/holochain/holochain/releases/download/holochain-0.6.1-rc.4/holochain-unstable-x86_64-unknown-linux-gnu
           nomad-job-variant-directory: "nomad/job-variants/canonical-scaled"
           include-threefold-node-pool: "true"
+          force-rebuild: ${{ inputs.rebuild-all-scenarios }}
 
   post-run-scenarios:
     needs: run-scenarios

--- a/.github/workflows/nomad-canonical.yaml
+++ b/.github/workflows/nomad-canonical.yaml
@@ -2,6 +2,12 @@ name: "Run canonical performance tests on Nomad cluster"
 
 on:
   workflow_dispatch:
+    inputs:
+      rebuild-all-scenarios:
+        description: "Force a rebuild of all scenarios even if no relevant files have changed"
+        type: boolean
+        required: false
+        default: false
   schedule:
     - cron: "0 0 * * 4" # Run Nomad workflow at 00:00 on Thursdays
 
@@ -61,6 +67,7 @@ jobs:
           holochain-bin-url: https://github.com/holochain/holochain/releases/download/holochain-0.6.1-rc.4/holochain-unstable-x86_64-unknown-linux-gnu
           nomad-job-variant-directory: "nomad/job-variants/canonical"
           include-threefold-node-pool: "false"
+          force-rebuild: ${{ inputs.rebuild-all-scenarios }}
 
   post-run-scenarios:
     needs: run-scenarios

--- a/.github/workflows/nomad-demo.yaml
+++ b/.github/workflows/nomad-demo.yaml
@@ -9,6 +9,11 @@ on:
       commit-hash:
         description: "The commit hash to checkout before running the tests"
         required: false
+      rebuild-all-scenarios:
+        description: "Force a rebuild of all scenarios even if no relevant files have changed"
+        type: boolean
+        required: false
+        default: false
   pull_request:
     paths:
       - ".github/workflows/nomad*.yaml"
@@ -70,6 +75,7 @@ jobs:
           commit-hash: ${{ inputs.commit-hash }}
           nomad-job-variant-directory: "nomad/job-variants/demo"
           include-threefold-node-pool: "false"
+          force-rebuild: ${{ inputs.rebuild-all-scenarios }}
 
   post-run-scenarios:
     needs: run-scenarios

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Create pre-release
         if: steps.check_release.outputs.exists == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
         run: |-
           tag="main-$(git rev-parse --short HEAD)"


### PR DESCRIPTION
### Option 1 of 2

> [!Note]
> There is an alternative version of this PR (#619) that uses the Nix input derivation hash to check for changes.

> [!Warning]
> Only one of this or #619 should be merged.

### Summary

This PR follows on from #618, and causes the scenarios to only be re-built, uploaded to the S3 bucket, and used by the Nomad nodes if the files relevant to that scenario have changed. Otherwise, the scenario zip files from the latest release or pre-release are used. It is possible to force a rebuild when running manually.

Must be merged after #618.

Closes #608.

Things that should trigger a rebuild of the scenarios:
```
├── bindings
│   ├── client ✔ (just HC ones)
│   ├── kitsune_client ✔ (just K2 ones)
│   ├── kitsune_runner ✔ (just K2 ones)
│   └── runner ✔ (just HC ones)
├── Cargo.lock ✔ (all because deps might have changed?)
├── Cargo.toml ✘ (covered by lock-file)
├── CHANGELOG.md ✘
├── CLAUDE.md ✘
├── dnas
│   └── <scenario-name> ✔ (just the scenario whose DNA changed)
├── durable_object_store/..
├── flake.lock ✘
├── flake.nix ✘
├── framework/.. ✔ (all)
├── happ_builder ✔ (just HC ones)
├── happs/.. ✘ (output dir I think)
├── influx/.. ✘
├── LICENSE ✘
├── logs ✘
├── lp-tool/.. ✘
├── Makefile ✘
├── nix
│   └── modules ✔ (HC ones, hApp builder might have changed)
├── node_modules ✘
├── nomad/.. ✘
├── README.md ✘
├── rust-toolchain.toml ✔ (all, rustc version might have changed)
├── scenarios
│   └── <scenario-name> ✔ (just the scenario whose DNA changed)
├── scenarios_common/.. ✔ (all)
├── scripts ✘
├── summariser ? (will this change how metrics are captured?)
├── summary-visualiser ✘
├── taplo.toml ✘
├── telegraf/.. ✘
├── threefold/.. ✘
└── zomes ✔ (all HC ones unless we can easily see which scenarios are effected)
```

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
