### PR TITLE
Publish scenarios to releases and pre-releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,8 +7,50 @@ on:
       - main-*
 
 jobs:
-  call:
+  full_release:
     uses: holochain/actions/.github/workflows/publish-release.yml@v1.6.0
     secrets:
       HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
       HRA2_CRATES_IO_TOKEN: ${{ secrets.HRA2_CRATES_IO_TOKEN }}
+
+  pre_releases:
+    name: Manage pre-releases
+    needs: [full_release]
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+
+      - name: Delete old pre-releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release list --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease and (.tagName | startswith("main-"))) | .tagName' \
+            | xargs -r -I % gh release delete % --yes --cleanup-tag
+
+      - name: Check if a full release exists for this commit
+        id: check_release
+        run: |
+          if [[ -n $(git tag --points-at HEAD) ]]; then
+            echo "A tag is on this commit, skipping pre-release creation."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pre-release
+        if: steps.check_release.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |-
+          tag="main-$(git rev-parse --short HEAD)"
+          gh release create "$tag" \
+            --prerelease \
+            --title "Scenarios pre-release ($tag)" \
+            --notes "Scenario binaries built from commit $(git rev-parse HEAD) on branch ${REF_NAME}."

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,6 +18,9 @@ jobs:
     needs: [full_release]
     if: github.ref_name == 'main'
     runs-on: ubuntu-latest
+    concurrency:
+      group: pre-release
+      cancel-in-progress: true
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-scenarios.yml
+++ b/.github/workflows/publish-scenarios.yml
@@ -1,0 +1,59 @@
+name: Publish scenarios
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish_scenarios:
+    name: Build and publish the scenarios
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@v5
+        with:
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-codeql: "true"
+          remove-docker-images: "true"
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.28.3/install
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: holochain-ci
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build scenarios
+        run: |
+          set -euxo pipefail
+
+          for scenario_dir in scenarios/*/; do
+            name=$(basename "$scenario_dir")
+            if [ -f "scenarios/$name/Cargo.toml" ]; then
+              nix build ".#packages.x86_64-linux.$name" --out-link "result-$name"
+              cp "result-$name/$name.zip" .
+            fi
+          done
+
+      - name: Upload scenarios to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          shopt -s nullglob
+          zips=(*.zip)
+          if [ ${#zips[@]} -eq 0 ]; then
+            echo "No scenario zip files were built, nothing to upload."
+            exit 1
+          fi
+          gh release upload "${{ github.event.release.tag_name }}" "${zips[@]}" --clobber

--- a/.github/workflows/publish-scenarios.yml
+++ b/.github/workflows/publish-scenarios.yml
@@ -14,6 +14,12 @@ jobs:
   publish_scenarios:
     name: Build and publish the scenarios
     runs-on: ubuntu-latest
+    concurrency:
+      # Pre-release builds share a cancellable group with publish-release.yml
+      # so a new push to main cancels an in-progress build. Full release builds
+      # use the tag name as the group so they are never cancelled.
+      group: ${{ github.event.release.prerelease && 'pre-release' || github.event.release.tag_name || inputs.tag }}
+      cancel-in-progress: true
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-scenarios.yml
+++ b/.github/workflows/publish-scenarios.yml
@@ -3,6 +3,12 @@ name: Publish scenarios
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish scenarios for"
+        required: true
+        type: string
 
 jobs:
   publish_scenarios:
@@ -12,6 +18,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
 
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@v5
@@ -56,4 +64,4 @@ jobs:
             echo "No scenario zip files were built, nothing to upload."
             exit 1
           fi
-          gh release upload "${{ github.event.release.tag_name }}" "${zips[@]}" --clobber
+          gh release upload "${{ inputs.tag || github.event.release.tag_name }}" "${zips[@]}" --clobber


### PR DESCRIPTION
### Summary

This PR is part of #608, it automatically creates a pre-release with the name `main-<commit-sha>` on a push to any of the main branches. There is also a new workflow that builds and publishes the scenario zip files whenever a new release (or pre-release) is published, this workflow can also be triggered manually to override existing scenario zips or add them to old releases.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
