### PR TITLE
Only build changed scenarios based on Nix input hash

### DIFF
--- a/.github/actions/nomad/action.yaml
+++ b/.github/actions/nomad/action.yaml
@@ -106,10 +106,13 @@ runs:
         current_hash=$(basename "$drv_path" .drv | cut -d'-' -f1)
         echo "Current Nix drv hash: $current_hash"
 
-        TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+        TAG=$(gh api "/repos/${GITHUB_REPOSITORY}/releases?per_page=10" \
+          | jq -r --arg name "${SCENARIO_NAME}.zip" \
+            '.[] | select(any(.assets[]; .name == $name)) | .tag_name' \
+          | head -1)
 
         if [[ -z "$TAG" ]]; then
-          echo "No release found, rebuilding"
+          echo "No release found containing ${SCENARIO_NAME}.zip, rebuilding"
           echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi

--- a/.github/actions/nomad/action.yaml
+++ b/.github/actions/nomad/action.yaml
@@ -84,12 +84,52 @@ runs:
       run: |
         nix run .#generate-nomad-jobs -- --job-name ${{ inputs.job-name }} --job-variant-path ${{ inputs.nomad-job-variant-directory }}
 
+    - name: Check if need to rebuild the scenario
+      id: needs-rebuild
+      shell: bash
+      env:
+        SCENARIO_NAME: ${{ steps.read-nomad-vars.outputs.scenario_name }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        drv_path=$(nix path-info --derivation ".#packages.x86_64-linux.${SCENARIO_NAME}")
+        current_hash=$(basename "$drv_path" .drv | cut -d'-' -f1)
+        echo "Current Nix drv hash: $current_hash"
+
+        TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+
+        if [[ -z "$TAG" ]]; then
+          echo "No release found, rebuilding"
+          echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        stored_hash=$(gh release download "$TAG" --repo "${GITHUB_REPOSITORY}" \
+          --pattern "${SCENARIO_NAME}.hash" --output - 2>/dev/null || true)
+
+        if [[ -z "$stored_hash" ]]; then
+          echo "No hash file found in release '$TAG', rebuilding"
+          echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "$stored_hash" != "$current_hash" ]]; then
+          echo "Hash changed (stored: $stored_hash, current: $current_hash), rebuilding"
+          echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "Hash matches ($current_hash), skipping rebuild — using release '$TAG'"
+        echo "needs_rebuild=false" >> "$GITHUB_OUTPUT"
+        echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
+
     - name: Build scenario
+      if: steps.needs-rebuild.outputs.needs_rebuild == 'true'
       shell: bash
       run: nix build .#packages.x86_64-linux.${{ steps.read-nomad-vars.outputs.scenario_name }}
 
     - name: Upload scenario to bucket
       id: upload-scenario
+      if: steps.needs-rebuild.outputs.needs_rebuild == 'true'
       shell: bash
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.hetzner-buckets-access }}
@@ -103,6 +143,23 @@ runs:
 
         echo "scenario_download_url=${AWS_ENDPOINT_URL}/${OUT_PATH}" >> "$GITHUB_OUTPUT"
         echo "Uploaded run scenario artifact to ${AWS_ENDPOINT_URL}/${OUT_PATH}" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Get scenario URL
+      id: get-scenario-url
+      shell: bash
+      env:
+        NEEDS_REBUILD: ${{ steps.needs-rebuild.outputs.needs_rebuild }}
+        NEW_SCENARIO_URL: ${{ steps.upload-scenario.outputs.scenario_download_url }}
+        SCENARIO_NAME: ${{ steps.read-nomad-vars.outputs.scenario_name }}
+        RELEASE_TAG: ${{ steps.needs-rebuild.outputs.release_tag }}
+      run: |-
+        if [[ "$NEEDS_REBUILD" == 'true' ]]; then
+          echo "Using newly built scenario from ${NEW_SCENARIO_URL}"
+          echo "scenario_download_url=${NEW_SCENARIO_URL}" >> "$GITHUB_OUTPUT"
+        else
+          echo "Using latest release of scenario from tag '${RELEASE_TAG}'"
+          echo "scenario_download_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${SCENARIO_NAME}.zip" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Wait For Minimum Free Nodes
       shell: bash
@@ -144,7 +201,7 @@ runs:
         NOMAD_ADDR: https://nomad-server-01.holochain.org:4646
         NOMAD_CACERT: "${{ github.workspace }}/nomad/server-ca-cert.pem"
         NOMAD_TOKEN: ${{ inputs.nomad-access-token }}
-        NOMAD_VAR_scenario_url: ${{ steps.upload-scenario.outputs.scenario_download_url }}
+        NOMAD_VAR_scenario_url: ${{ steps.get-scenario-url.outputs.scenario_download_url }}
         NOMAD_VAR_run_id: ${{ env.RUN_ID }}
         NOMAD_VAR_holochain_bin_url: ${{ inputs.holochain-bin-url }}
         NOMAD_VAR_include_threefold_node_pool: ${{ inputs.include-threefold-node-pool }}
@@ -177,7 +234,7 @@ runs:
         NOMAD_ADDR: https://nomad-server-01.holochain.org:4646
         NOMAD_CACERT: "${{ github.workspace }}/nomad/server-ca-cert.pem"
         NOMAD_TOKEN: ${{ inputs.nomad-access-token }}
-        NOMAD_VAR_scenario_url: ${{ steps.upload-scenario.outputs.scenario_download_url }}
+        NOMAD_VAR_scenario_url: ${{ steps.get-scenario-url.outputs.scenario_download_url }}
         NOMAD_VAR_run_id: ${{ env.RUN_ID }}
         NOMAD_VAR_holochain_bin_url: ${{ inputs.holochain-bin-url }}
         NOMAD_VAR_include_threefold_node_pool: ${{ inputs.include-threefold-node-pool }}

--- a/.github/actions/nomad/action.yaml
+++ b/.github/actions/nomad/action.yaml
@@ -28,6 +28,10 @@ inputs:
     required: true
   cachix-auth-token:
     required: true
+  force-rebuild:
+    description: "Force a rebuild of the scenario even if its input hash hasn't changed"
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -89,8 +93,15 @@ runs:
       shell: bash
       env:
         SCENARIO_NAME: ${{ steps.read-nomad-vars.outputs.scenario_name }}
+        FORCE_REBUILD: ${{ inputs.force-rebuild }}
         GH_TOKEN: ${{ github.token }}
       run: |
+        if [[ "$FORCE_REBUILD" == 'true' ]]; then
+          echo "Force rebuild requested"
+          echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         drv_path=$(nix path-info --derivation ".#packages.x86_64-linux.${SCENARIO_NAME}")
         current_hash=$(basename "$drv_path" .drv | cut -d'-' -f1)
         echo "Current Nix drv hash: $current_hash"

--- a/.github/workflows/nomad-canonical-scaled.yaml
+++ b/.github/workflows/nomad-canonical-scaled.yaml
@@ -2,6 +2,12 @@ name: "Run canonical scaled performance tests on Nomad cluster and Threefold nod
 
 on:
   workflow_dispatch:
+    inputs:
+      rebuild-all-scenarios:
+        description: "Force a rebuild of all scenarios even if input hashes haven't changed"
+        type: boolean
+        required: false
+        default: false
   schedule:
     - cron: "0 0 * * 5" # Run Nomad workflow at 00:00 on Fridays
 
@@ -124,6 +130,7 @@ jobs:
           holochain-bin-url: https://github.com/holochain/holochain/releases/download/holochain-0.6.1-rc.4/holochain-unstable-x86_64-unknown-linux-gnu
           nomad-job-variant-directory: "nomad/job-variants/canonical-scaled"
           include-threefold-node-pool: "true"
+          force-rebuild: ${{ inputs.rebuild-all-scenarios }}
 
   post-run-scenarios:
     needs: run-scenarios

--- a/.github/workflows/nomad-canonical.yaml
+++ b/.github/workflows/nomad-canonical.yaml
@@ -2,6 +2,12 @@ name: "Run canonical performance tests on Nomad cluster"
 
 on:
   workflow_dispatch:
+    inputs:
+      rebuild-all-scenarios:
+        description: "Force a rebuild of all scenarios even if input hashes haven't changed"
+        type: boolean
+        required: false
+        default: false
   schedule:
     - cron: "0 0 * * 4" # Run Nomad workflow at 00:00 on Thursdays
 
@@ -61,6 +67,7 @@ jobs:
           holochain-bin-url: https://github.com/holochain/holochain/releases/download/holochain-0.6.1-rc.4/holochain-unstable-x86_64-unknown-linux-gnu
           nomad-job-variant-directory: "nomad/job-variants/canonical"
           include-threefold-node-pool: "false"
+          force-rebuild: ${{ inputs.rebuild-all-scenarios }}
 
   post-run-scenarios:
     needs: run-scenarios

--- a/.github/workflows/nomad-demo.yaml
+++ b/.github/workflows/nomad-demo.yaml
@@ -9,6 +9,11 @@ on:
       commit-hash:
         description: "The commit hash to checkout before running the tests"
         required: false
+      rebuild-all-scenarios:
+        description: "Force a rebuild of all scenarios even if input hashes haven't changed"
+        type: boolean
+        required: false
+        default: false
   pull_request:
     paths:
       - ".github/workflows/nomad*.yaml"
@@ -70,6 +75,7 @@ jobs:
           commit-hash: ${{ inputs.commit-hash }}
           nomad-job-variant-directory: "nomad/job-variants/demo"
           include-threefold-node-pool: "false"
+          force-rebuild: ${{ inputs.rebuild-all-scenarios }}
 
   post-run-scenarios:
     needs: run-scenarios

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Create pre-release
         if: steps.check_release.outputs.exists == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
         run: |-
           tag="main-$(git rev-parse --short HEAD)"

--- a/.github/workflows/publish-scenarios.yml
+++ b/.github/workflows/publish-scenarios.yml
@@ -57,6 +57,10 @@ jobs:
             if [ -f "scenarios/$name/Cargo.toml" ]; then
               nix build ".#packages.x86_64-linux.$name" --out-link "result-$name"
               cp "result-$name/$name.zip" .
+              # Store the Nix derivation hash alongside the zip so the nomad
+              # action can skip rebuilds when inputs haven't changed.
+              drv_path=$(nix path-info --derivation ".#packages.x86_64-linux.$name")
+              basename "$drv_path" .drv | cut -d'-' -f1 > "$name.hash"
             fi
           done
 
@@ -70,4 +74,5 @@ jobs:
             echo "No scenario zip files were built, nothing to upload."
             exit 1
           fi
-          gh release upload "${{ inputs.tag || github.event.release.tag_name }}" "${zips[@]}" --clobber
+          hashes=(*.hash)
+          gh release upload "${{ inputs.tag || github.event.release.tag_name }}" "${zips[@]}" "${hashes[@]}" --clobber


### PR DESCRIPTION
### Option 2 of 2

> [!Note]
> This is an alternative to #613.

> [!Warning]
> Only one of this or #613 should be merged.

### Summary

This is an alternative to #613 but whereas that one triggers rebuilds based on what files changed, this PR instead calculates the Nix input derivation hashes of each scenario and compares it to the one stored for the latest release and rebuilds scenarios where this differs.

This means that the hash needs to be stored with the release and then recalculated in every PR to check for changes but it should be more robust as it should detect any changes instead of just the ones specified.

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
