### PR TITLE
ci: notifiy the public Wind Tunnel channel on failures

### DIFF
--- a/.github/workflows/nomad-canonical-scaled.yaml
+++ b/.github/workflows/nomad-canonical-scaled.yaml
@@ -183,7 +183,7 @@ jobs:
         if: ${{ failure() }}
         with:
           MATTERMOST_PERSONAL_ACCESS_TOKEN: ${{ secrets.HOLOCHAIN_NOTIFIER_MATTERMOST_PERSONAL_ACCESS_TOKEN }}
-          channel_id: cxskxqhb37rtjp5w8myri3pdhh # HCF Tech channel
+          channel_id: w3wnjwotkty9fbuo1qa5aqq86a # dev/wind-tunnel channel
           message: |-
             ALERT! A nomad canonical-scaled workflow run *failed* to cancel all Threefold node contracts.
             You may need to visit the [Threefold grid dashboard](https://dashboard.grid.tf/) to cancel all contracts manually.


### PR DESCRIPTION
### Summary

The bot used to notify the team upon failures can only post in public channels and `HCF Tech` is private.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
