### PR TITLE
fix(nomad): fallback failed `fetch_peer_end_count` to zero

### DIFF
--- a/nomad/scripts/ci_allocs.sh
+++ b/nomad/scripts/ci_allocs.sh
@@ -75,7 +75,7 @@ function generate_run_summary() {
     declare -A peer_end_count_by_run
     while IFS=',' read -r _job_name _scenario_name alloc_id _run_id _started_at _duration _peer_count _behaviours; do
         local this_alloc_peer_end_count
-        this_alloc_peer_end_count=$(fetch_peer_end_count "$alloc_id" "$_peer_count")
+        this_alloc_peer_end_count=$(fetch_peer_end_count "$alloc_id")
         peer_end_count_by_run["$_run_id"]="$(( ${peer_end_count_by_run["$_run_id"]:-0} + this_alloc_peer_end_count ))"
     done < "$allocs_csv_file"
 
@@ -149,12 +149,11 @@ function holochain_build_info() {
 
 function fetch_peer_end_count() {
     local alloc_id="$1"
-    local fallback_peer_count="$2"
     local result
     result=$(nomad alloc fs "$alloc_id" alloc/run_summary.jsonl 2>/dev/null | jq --slurp 'last | .peer_end_count') || result=""
     if [[ -z "$result" || "$result" == "null" ]]; then
-        echo "Warning: could not fetch peer_end_count for alloc $alloc_id, falling back to configured peer_count ($fallback_peer_count)" >&2
-        echo "$fallback_peer_count"
+        echo "Warning: could not fetch peer_end_count for alloc $alloc_id, assuming 0 peers completed" >&2
+        echo 0
         return
     fi
     echo "Fetched peer_end_count for alloc $alloc_id: $result" >&2


### PR DESCRIPTION
### Summary

instead of fallbacking on the `peer_count` value, which leads to wrong `end_peer_count`, we just fallback to zero if the fetch fails

closes #588

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
