### PR TITLE
docs: add new-scenario checklist to PR template and CLAUDE.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 - [ ] All code changes are reflected in docs, including module-level docs
 - [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
 - [ ] I ran the Nomad CI workflow successfully on my branch
+- [ ] If this PR adds a new scenario, I have copied the [new scenario checklist](https://github.com/holochain/wind-tunnel/tree/main/docs/new-scenario-checklist.md) into this PR description and ticked off each applicable item
 
 
 _Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,3 +137,7 @@ When reviewing pull requests:
 ## Code Hygiene
 
 - Generated Rust and TOML must always be properly formatted, if you're not sure then run `cargo fmt` or `taplo format` on the relevant files.
+
+## New Scenario Checklist
+
+When a PR adds a new scenario (a Rust project under `scenarios/`), verify that every applicable item from [`docs/new-scenario-checklist.md`](docs/new-scenario-checklist.md) is addressed. The checklist covers core implementation, CI smoke tests, Nomad deployment (`canonical`, `demo`, and optionally `canonical-scaled` variants plus their workflow `job-name` matrices), summariser integration, and summary visualiser templates. Summariser and summary visualiser items are optional only if a tracking issue is linked from the PR; otherwise they are required.

--- a/docs/new-scenario-checklist.md
+++ b/docs/new-scenario-checklist.md
@@ -1,0 +1,38 @@
+# New Scenario Checklist
+
+Use this checklist when a PR adds a new scenario to wind-tunnel. Copy the relevant items into the PR description and tick them off as the work lands.
+
+## Core implementation
+
+- [ ] Scenario binary created in `scenarios/<scenario_name>/` with `Cargo.toml` and `src/main.rs`
+- [ ] Scenario added to workspace `members` in root `Cargo.toml`
+- [ ] Scenario `Cargo.toml` has `[package.metadata]` present (even if empty, required for the hApp builder)
+- [ ] If the scenario uses Holochain hApps/DNAs: `Cargo.toml` declares one of `[package.metadata.required-dna]`, `[package.metadata.required-happ]`, or `[package.metadata.fetch-required-happ]`
+- [ ] `Cargo.toml` sets `build = "../scenario_build.rs"`
+- [ ] Scenario code reports all behavior-changing environment variables via `ScenarioDefinitionBuilder::add_capture_env`
+- [ ] Scenario README added with: purpose, env variables, metrics recorded, and instructions to run locally
+
+## CI / Smoke tests
+
+- [ ] Smoke test added to `.github/workflows/test.yaml`
+
+## Nomad deployment
+
+- [ ] Scenario vars JSON added to `nomad/job-variants/canonical/vars/<scenario_name>.json`
+- [ ] Scenario vars JSON added to `nomad/job-variants/demo/vars/<scenario_name>.json`
+- [ ] Scenario vars JSON added to `nomad/job-variants/canonical-scaled/vars/<scenario_name>.json` (only if scenario should run in the scaled estate)
+- [ ] Scenario added to `job-name` matrix in `.github/workflows/nomad-canonical.yaml`
+- [ ] Scenario added to `job-name` matrix in `.github/workflows/nomad-demo.yaml`
+- [ ] Scenario added to `job-name` matrix in `.github/workflows/nomad-canonical-scaled.yaml` (only if applicable)
+
+## Summariser (optional — implement or link tracking issue)
+
+- [ ] Summariser scenario module added in `summariser/src/scenario/<scenario_name>.rs`
+- [ ] Module registered in `summariser/src/scenario.rs` and dispatched in `summariser/src/lib.rs`
+- [ ] Test data captured (run summaries, query results, snapshot outputs under `summariser/test_data/`)
+- [ ] Capture entry added to `summariser/capture_all.sh`
+
+## Summary visualiser (optional — implement or link tracking issue)
+
+- [ ] Template added to `summary-visualiser/templates/scenarios/<scenario_name>.html.tmpl`
+- [ ] Smoke test line added to `summary-visualiser/test.sh`


### PR DESCRIPTION
### Summary

Added checklist for adding new scenarios to the wind-tunnel project. Also added CLAUDE context for checklist when adding new scenarios.

Closes #591

### Checklist

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
