### PR TITLE
chore: reduce canonical node targets from 65 to 30

### DIFF
--- a/nomad/job-variants/canonical/vars/dht_sync_lag.json
+++ b/nomad/job-variants/canonical/vars/dht_sync_lag.json
@@ -1,16 +1,16 @@
 {
   "job_name": "dht_sync_lag_canonical",
-  "description": "55 write nodes produce DHT load; 10 observer nodes measure sync lag. Target 85/15 write/observe; actual 84.6/15.4 at 65 nodes.",
+  "description": "25 write nodes produce DHT load; 5 observer nodes measure sync lag. Target 85/15 write/observe; actual 83.3/16.7 at 30 nodes.",
   "scenario_name": "dht_sync_lag",
   "duration": 1800,
   "assignments": [
     {
       "behaviour": "write",
-      "nodes": 55
+      "nodes": 25
     },
     {
       "behaviour": "record_lag",
-      "nodes": 10
+      "nodes": 5
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/full_arc_create_validated_zero_arc_read--high_zero.json
+++ b/nomad/job-variants/canonical/vars/full_arc_create_validated_zero_arc_read--high_zero.json
@@ -1,16 +1,16 @@
 {
   "job_name": "full_arc_create_validated_zero_arc_read_canonical--high_zero",
-  "description": "61 zero-arc nodes read validated entries created by 4 full-arc writers. Target 94% zero arc; actual 93.8% at 65 nodes.",
+  "description": "28 zero-arc nodes read validated entries created by 2 full-arc writers. Target 94% zero arc; actual 93.3% at 30 nodes.",
   "scenario_name": "full_arc_create_validated_zero_arc_read",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "zero",
-      "nodes": 61
+      "nodes": 28
     },
     {
       "behaviour": "full",
-      "nodes": 4
+      "nodes": 2
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/full_arc_create_validated_zero_arc_read.json
+++ b/nomad/job-variants/canonical/vars/full_arc_create_validated_zero_arc_read.json
@@ -1,16 +1,16 @@
 {
   "job_name": "full_arc_create_validated_zero_arc_read_canonical",
-  "description": "56 zero-arc nodes read validated entries created by 9 full-arc writers. Target 86% zero arc; actual 86.2% at 65 nodes.",
+  "description": "26 zero-arc nodes read validated entries created by 4 full-arc writers. Target 86% zero arc; actual 86.7% at 30 nodes.",
   "scenario_name": "full_arc_create_validated_zero_arc_read",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "zero",
-      "nodes": 56
+      "nodes": 26
     },
     {
       "behaviour": "full",
-      "nodes": 9
+      "nodes": 4
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/mixed_arc_get_agent_activity.json
+++ b/nomad/job-variants/canonical/vars/mixed_arc_get_agent_activity.json
@@ -1,20 +1,20 @@
 {
   "job_name": "mixed_arc_get_agent_activity_canonical",
-  "description": "23 zero-arc and 23 full-arc nodes write; 19 zero-arc nodes query agent activity. Target 70/30 write/read; actual 70.8/29.2 at 65 nodes.",
+  "description": "10 zero-arc and 11 full-arc nodes write; 9 zero-arc nodes query agent activity. Target 70/30 write/read; actual 70/30 at 30 nodes.",
   "scenario_name": "mixed_arc_get_agent_activity",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "zero_read",
-      "nodes": 19
+      "nodes": 9
     },
     {
       "behaviour": "zero_write",
-      "nodes": 23
+      "nodes": 10
     },
     {
       "behaviour": "full_write",
-      "nodes": 23
+      "nodes": 11
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/mixed_arc_must_get_agent_activity.json
+++ b/nomad/job-variants/canonical/vars/mixed_arc_must_get_agent_activity.json
@@ -1,20 +1,20 @@
 {
   "job_name": "mixed_arc_must_get_agent_activity_canonical",
-  "description": "23 zero-arc and 23 full-arc nodes write; 19 zero-arc nodes use must_get_agent_activity. Target 70/30 write/read; actual 70.8/29.2 at 65 nodes.",
+  "description": "10 zero-arc and 11 full-arc nodes write; 9 zero-arc nodes use must_get_agent_activity. Target 70/30 write/read; actual 70/30 at 30 nodes.",
   "scenario_name": "mixed_arc_must_get_agent_activity",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "zero_must_get_agent_activity",
-      "nodes": 19
+      "nodes": 9
     },
     {
       "behaviour": "zero_write",
-      "nodes": 23
+      "nodes": 10
     },
     {
       "behaviour": "full_write",
-      "nodes": 23
+      "nodes": 11
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/unyt_chain_transaction.json
+++ b/nomad/job-variants/canonical/vars/unyt_chain_transaction.json
@@ -1,6 +1,6 @@
 {
   "job_name": "unyt_chain_transaction_canonical",
-  "description": "1 progenitor initialises the network; 32 spend and 32 smart_agreements agents run concurrent transactions. Target 50/50 spend/smart_agreements; actual 50/50 at 64 transaction agents (65 nodes total).",
+  "description": "1 progenitor initialises the network; 15 spend and 14 smart_agreements agents run concurrent transactions. Target 50/50 spend/smart_agreements; actual 51.7/48.3 at 29 transaction agents (30 nodes total).",
   "scenario_name": "unyt_chain_transaction",
   "duration": 900,
   "assignments": [
@@ -9,15 +9,15 @@
     },
     {
       "behaviour": "spend",
-      "nodes": 32
+      "nodes": 15
     },
     {
       "behaviour": "smart_agreements",
-      "nodes": 32
+      "nodes": 14
     }
   ],
   "env": {
-    "MIN_AGENTS": "65",
+    "MIN_AGENTS": "30",
     "UNYT_NUMBER_OF_LINKS_TO_PROCESS": "10"
   }
 }

--- a/nomad/job-variants/canonical/vars/unyt_proposal.json
+++ b/nomad/job-variants/canonical/vars/unyt_proposal.json
@@ -1,5 +1,5 @@
 {
-  "description": "1 progenitor initialises the network; 32 propose and 32 respond agents run concurrent proposal flows. Target 50/50 propose/respond; actual 50/50 at 64 proposal agents (65 nodes total).",
+  "description": "1 progenitor initialises the network; 15 propose and 14 respond agents run concurrent proposal flows. Target 50/50 propose/respond; actual 51.7/48.3 at 29 proposal agents (30 nodes total).",
   "job_name": "unyt_proposal_canonical",
   "scenario_name": "unyt_proposal",
   "duration": 900,
@@ -9,15 +9,15 @@
     },
     {
       "behaviour": "propose",
-      "nodes": 32
+      "nodes": 15
     },
     {
       "behaviour": "respond",
-      "nodes": 32
+      "nodes": 14
     }
   ],
   "env": {
-    "MIN_AGENTS": "65",
+    "MIN_AGENTS": "30",
     "UNYT_NUMBER_OF_LINKS_TO_PROCESS": "10",
     "UNYT_PROPOSER_WEIGHTS": "60,20,20",
     "UNYT_RESPONDER_WEIGHTS": "60,20,20",

--- a/nomad/job-variants/canonical/vars/write_get_agent_activity.json
+++ b/nomad/job-variants/canonical/vars/write_get_agent_activity.json
@@ -1,16 +1,16 @@
 {
   "job_name": "write_get_agent_activity_canonical",
-  "description": "19 write nodes produce chain entries; 46 read nodes query agent activity. Target 30/70 write/read; actual 29.2/70.8 at 65 nodes.",
+  "description": "9 write nodes produce chain entries; 21 read nodes query agent activity. Target 30/70 write/read; actual 30/70 at 30 nodes.",
   "scenario_name": "write_get_agent_activity",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "write",
-      "nodes": 19
+      "nodes": 9
     },
     {
       "behaviour": "get_agent_activity",
-      "nodes": 46
+      "nodes": 21
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/write_get_agent_activity_volatile.json
+++ b/nomad/job-variants/canonical/vars/write_get_agent_activity_volatile.json
@@ -1,16 +1,16 @@
 {
   "job_name": "write_get_agent_activity_volatile_canonical",
-  "description": "19 write nodes produce chain entries; 46 nodes make volatile agent activity queries. Target 30/70 write/read; actual 29.2/70.8 at 65 nodes.",
+  "description": "9 write nodes produce chain entries; 21 nodes make volatile agent activity queries. Target 30/70 write/read; actual 30/70 at 30 nodes.",
   "scenario_name": "write_get_agent_activity_volatile",
   "duration": 1800,
   "assignments": [
     {
       "behaviour": "write",
-      "nodes": 19
+      "nodes": 9
     },
     {
       "behaviour": "get_agent_activity_volatile",
-      "nodes": 46
+      "nodes": 21
     }
   ],
   "env": {

--- a/nomad/job-variants/canonical/vars/write_validated_must_get_agent_activity.json
+++ b/nomad/job-variants/canonical/vars/write_validated_must_get_agent_activity.json
@@ -1,16 +1,16 @@
 {
   "job_name": "write_validated_must_get_agent_activity_canonical",
-  "description": "19 write nodes produce validated entries; 46 nodes use must_get_agent_activity. Target 30/70 write/read; actual 29.2/70.8 at 65 nodes.",
+  "description": "9 write nodes produce validated entries; 21 nodes use must_get_agent_activity. Target 30/70 write/read; actual 30/70 at 30 nodes.",
   "scenario_name": "write_validated_must_get_agent_activity",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "write",
-      "nodes": 19
+      "nodes": 9
     },
     {
       "behaviour": "must_get_agent_activity",
-      "nodes": 46
+      "nodes": 21
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/zero_arc_create_and_read.json
+++ b/nomad/job-variants/canonical/vars/zero_arc_create_and_read.json
@@ -1,20 +1,20 @@
 {
   "job_name": "zero_arc_create_and_read_canonical",
-  "description": "26 zero-arc writers, 26 zero-arc readers, and 13 full-arc nodes. Target 80/20 zero/full arc; exactly achieved at 65 nodes.",
+  "description": "12 zero-arc writers, 12 zero-arc readers, and 6 full-arc nodes. Target 80/20 zero/full arc; exactly achieved at 30 nodes.",
   "scenario_name": "zero_arc_create_and_read",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "zero_write",
-      "nodes": 26
+      "nodes": 12
     },
     {
       "behaviour": "zero_read",
-      "nodes": 26
+      "nodes": 12
     },
     {
       "behaviour": "full",
-      "nodes": 13
+      "nodes": 6
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/zero_arc_create_data--high_zero.json
+++ b/nomad/job-variants/canonical/vars/zero_arc_create_data--high_zero.json
@@ -1,16 +1,16 @@
 {
   "job_name": "zero_arc_create_data_canonical--high_zero",
-  "description": "61 zero-arc nodes create entries; 4 full-arc nodes serve the DHT. Target 94% zero arc; actual 93.8% at 65 nodes.",
+  "description": "28 zero-arc nodes create entries; 2 full-arc nodes serve the DHT. Target 94% zero arc; actual 93.3% at 30 nodes.",
   "scenario_name": "zero_arc_create_data",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "zero",
-      "nodes": 61
+      "nodes": 28
     },
     {
       "behaviour": "full",
-      "nodes": 4
+      "nodes": 2
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/zero_arc_create_data.json
+++ b/nomad/job-variants/canonical/vars/zero_arc_create_data.json
@@ -1,16 +1,16 @@
 {
   "job_name": "zero_arc_create_data_canonical",
-  "description": "56 zero-arc nodes create entries; 9 full-arc nodes serve the DHT. Target 86% zero arc; actual 86.2% at 65 nodes.",
+  "description": "26 zero-arc nodes create entries; 4 full-arc nodes serve the DHT. Target 86% zero arc; actual 86.7% at 30 nodes.",
   "scenario_name": "zero_arc_create_data",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "zero",
-      "nodes": 56
+      "nodes": 26
     },
     {
       "behaviour": "full",
-      "nodes": 9
+      "nodes": 4
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/zero_arc_create_data_validated--high_zero.json
+++ b/nomad/job-variants/canonical/vars/zero_arc_create_data_validated--high_zero.json
@@ -1,16 +1,16 @@
 {
   "job_name": "zero_arc_create_data_validated_canonical--high_zero",
-  "description": "61 zero-arc nodes create validated entries; 4 full-arc nodes serve the DHT. Target 94% zero arc; actual 93.8% at 65 nodes.",
+  "description": "28 zero-arc nodes create validated entries; 2 full-arc nodes serve the DHT. Target 94% zero arc; actual 93.3% at 30 nodes.",
   "scenario_name": "zero_arc_create_data_validated",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "zero",
-      "nodes": 61
+      "nodes": 28
     },
     {
       "behaviour": "full",
-      "nodes": 4
+      "nodes": 2
     }
   ]
 }

--- a/nomad/job-variants/canonical/vars/zero_arc_create_data_validated.json
+++ b/nomad/job-variants/canonical/vars/zero_arc_create_data_validated.json
@@ -1,16 +1,16 @@
 {
   "job_name": "zero_arc_create_data_validated_canonical",
-  "description": "56 zero-arc nodes create validated entries; 9 full-arc nodes serve the DHT. Target 86% zero arc; actual 86.2% at 65 nodes.",
+  "description": "26 zero-arc nodes create validated entries; 4 full-arc nodes serve the DHT. Target 86% zero arc; actual 86.7% at 30 nodes.",
   "scenario_name": "zero_arc_create_data_validated",
   "duration": 900,
   "assignments": [
     {
       "behaviour": "zero",
-      "nodes": 56
+      "nodes": 26
     },
     {
       "behaviour": "full",
-      "nodes": 9
+      "nodes": 4
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/holochain/wind-tunnel/issues/630, using a reduced node count as a solution to the previous run failing.

- Several machines used for canonical runs are no longer available, so the canonical job variants that targeted 65 nodes are scaled down to 30, preserving each documented behaviour ratio.
- Clean splits (ratio exact or near-exact): \`zero_arc_create_and_read\` 12/12/6 (80/20); \`write_get_agent_activity\`, \`write_get_agent_activity_volatile\`, \`write_validated_must_get_agent_activity\` 9/21 (30/70); \`full_arc_create_validated_zero_arc_read\` and \`zero_arc_create_data*\` 26/4 (86.7%) and 28/2 high-zero (93.3%); \`dht_sync_lag\` 25/5 (83.3/16.7).
- Two compromises:
  - \`mixed_arc_get_agent_activity\` / \`mixed_arc_must_get_agent_activity\`: write/read stays exactly 70/30 (21 writers / 9 readers), but the 21 writers can no longer split evenly; set to 10 zero-arc / 11 full-arc to keep the overall zero/full balance closest to the original ~65/35.
  - \`unyt_chain_transaction\` / \`unyt_proposal\`: 1 progenitor + 29 transaction agents is odd, so 50/50 becomes 15/14 (51.7/48.3); \`MIN_AGENTS\` dropped 65→30.
- Descriptions updated to reflect new counts and recomputed percentages. Variants already using ≤30 nodes were left untouched.