### PR TITLE
feat: add soft affinity toward nodes with unyt_agent_id meta

### DIFF
--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -71,6 +71,13 @@ job "{{ (ds "vars").job_name }}" {
     value     = ">= 1.11.0"
   }
 
+  # Soft preference: weight toward nodes where the meta is set
+  affinity {
+    attribute = "${meta.unyt_agent_id}"
+    operator  = "is_set"
+    weight    = 100
+  }
+
   secret "job_secrets" {
     provider = "nomad"
     path     = "nomad/jobs"

--- a/nomad/run_scenario.tpl.hcl
+++ b/nomad/run_scenario.tpl.hcl
@@ -74,7 +74,8 @@ job "{{ (ds "vars").job_name }}" {
   # Soft preference: weight toward nodes where the meta is set
   affinity {
     attribute = "${meta.unyt_agent_id}"
-    operator  = "is_set"
+    operator  = "regexp"
+    value     = ".+"
     weight    = 100
   }
 


### PR DESCRIPTION
### Summary

Adds an affinity that will choose nodes with unyt_agent_ids if available.

Here is a [demo run](https://github.com/holochain/wind-tunnel/actions/runs/28607335262)  that successfully pulled in the nodes with unyt-agent-ids for the run.
