### PR TITLE
fix(threefold): skip opted-out nodes during allocation

### DIFF
--- a/.github/workflows/nomad-canonical-scaled.yaml
+++ b/.github/workflows/nomad-canonical-scaled.yaml
@@ -15,11 +15,21 @@ concurrency:
   group: nomad # This is the same group as all other Nomad workflows
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy-threefold-nodes:
     runs-on: ubuntu-latest
+    outputs:
+      threefold_address: ${{ steps.tf-balance-before.outputs.address }}
+      threefold_free_tft_before: ${{ steps.tf-balance-before.outputs.free_tft }}
+      threefold_reserved_tft_before: ${{ steps.tf-balance-before.outputs.reserved_tft }}
+      threefold_spendable_tft_before: ${{ steps.tf-balance-before.outputs.spendable_tft }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install nix
         uses: cachix/install-nix-action@v31
@@ -29,6 +39,18 @@ jobs:
         with:
           name: holochain-ci
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Snapshot ThreeFold balance before run
+        id: tf-balance-before
+        env:
+          THREEFOLD_TFCHAIN_WALLET_MNEMONIC: ${{ secrets.THREEFOLD_TFCHAIN_WALLET_MNEMONIC }}
+        run: |
+          set -euo pipefail
+
+          nix develop .#ci --command deployer account-snapshot \
+            --mnemonic "$THREEFOLD_TFCHAIN_WALLET_MNEMONIC" \
+            --network main \
+            --format github >> "$GITHUB_OUTPUT"
 
       - name: Check available nodes in nomad
         id: check-available-nomad-nodes
@@ -49,6 +71,7 @@ jobs:
         timeout-minutes: 120
         env:
           THREEFOLD_TFCHAIN_WALLET_MNEMONIC: ${{ secrets.THREEFOLD_TFCHAIN_WALLET_MNEMONIC }}
+          AVAILABLE_NOMAD_NODES: ${{ steps.check-available-nomad-nodes.outputs.count }}
 
           # Additional nodes provisioned in case some fail to deploy. In practice this seems to happen infrequently.
           THREEFOLD_NODES_BUFFER_COUNT: 20
@@ -60,7 +83,7 @@ jobs:
             nomad/job-variants/canonical-scaled/vars/*.json)
 
           # Determine number of additional nodes needed
-          AVAILABLE_NODES="${{ steps.check-available-nomad-nodes.outputs.count }}"
+          AVAILABLE_NODES="$AVAILABLE_NOMAD_NODES"
           MIN_THREEFOLD_NODES_COUNT=$(( MAX_SCENARIO_NODES_COUNT - AVAILABLE_NODES ))
 
           echo "Available nodes: $AVAILABLE_NODES"
@@ -120,6 +143,8 @@ jobs:
     timeout-minutes: 480
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/nomad
         with:
@@ -150,10 +175,14 @@ jobs:
 
   remove-threefold-nodes:
     runs-on: ubuntu-latest
-    needs: post-run-scenarios
+    needs:
+      - deploy-threefold-nodes
+      - post-run-scenarios
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install nix
         uses: cachix/install-nix-action@v31
@@ -178,6 +207,62 @@ jobs:
 
           # Cancel all threefold deployment contracts
           nix develop .#ci --command tf-grid-cmd cancel contracts -a
+
+      - name: Snapshot ThreeFold balance after cleanup
+        id: tf-balance-after
+        if: ${{ always() }}
+        env:
+          THREEFOLD_TFCHAIN_WALLET_MNEMONIC: ${{ secrets.THREEFOLD_TFCHAIN_WALLET_MNEMONIC }}
+        run: |
+          set -euo pipefail
+
+          nix develop .#ci --command deployer account-snapshot \
+            --mnemonic "$THREEFOLD_TFCHAIN_WALLET_MNEMONIC" \
+            --network main \
+            --format github >> "$GITHUB_OUTPUT"
+
+      - name: Report ThreeFold credit usage
+        if: ${{ always() }}
+        env:
+          THREEFOLD_ADDRESS: ${{ needs.deploy-threefold-nodes.outputs.threefold_address }}
+          BEFORE_FREE_TFT: ${{ needs.deploy-threefold-nodes.outputs.threefold_free_tft_before }}
+          BEFORE_RESERVED_TFT: ${{ needs.deploy-threefold-nodes.outputs.threefold_reserved_tft_before }}
+          BEFORE_SPENDABLE_TFT: ${{ needs.deploy-threefold-nodes.outputs.threefold_spendable_tft_before }}
+          AFTER_FREE_TFT: ${{ steps.tf-balance-after.outputs.free_tft }}
+          AFTER_RESERVED_TFT: ${{ steps.tf-balance-after.outputs.reserved_tft }}
+          AFTER_SPENDABLE_TFT: ${{ steps.tf-balance-after.outputs.spendable_tft }}
+        run: |
+          set -euo pipefail
+
+          numeric_re='^[0-9]+([.][0-9]+)?$'
+          cost_tft="unknown"
+          remaining_weeks="unknown"
+          remaining_months="unknown"
+
+          if [[ "$BEFORE_FREE_TFT" =~ $numeric_re && "$AFTER_FREE_TFT" =~ $numeric_re ]]; then
+            cost_tft="$(awk -v before="$BEFORE_FREE_TFT" -v after="$AFTER_FREE_TFT" 'BEGIN { printf "%.7f", before - after }')"
+            if awk -v cost="$cost_tft" 'BEGIN { exit !(cost > 0) }'; then
+              remaining_weeks="$(awk -v balance="$AFTER_FREE_TFT" -v cost="$cost_tft" 'BEGIN { printf "%.2f", balance / cost }')"
+              remaining_months="$(awk -v weeks="$remaining_weeks" 'BEGIN { printf "%.2f", weeks / 4.345 }')"
+            fi
+          fi
+
+          {
+            echo "## ThreeFold credit"
+            echo ""
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Wallet address | ${THREEFOLD_ADDRESS:-unknown} |"
+            echo "| Spendable balance before run | ${BEFORE_SPENDABLE_TFT:-unknown} TFT |"
+            echo "| Spendable balance after cleanup | ${AFTER_SPENDABLE_TFT:-unknown} TFT |"
+            echo "| Estimated run cost | ${cost_tft} TFT |"
+            echo "| Estimated remaining weekly runs | ${remaining_weeks} |"
+            echo "| Estimated remaining months | ${remaining_months} |"
+            echo "| Free balance before run | ${BEFORE_FREE_TFT:-unknown} TFT |"
+            echo "| Free balance after cleanup | ${AFTER_FREE_TFT:-unknown} TFT |"
+            echo "| Reserved balance before run | ${BEFORE_RESERVED_TFT:-unknown} TFT |"
+            echo "| Reserved balance after cleanup | ${AFTER_RESERVED_TFT:-unknown} TFT |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Notify team via Mattermost if cancellation failed
         uses: holochain/actions/mattermost-notify@v1.12.0

--- a/threefold/deployer/go.mod
+++ b/threefold/deployer/go.mod
@@ -3,8 +3,11 @@ module wind-tunnel/threefold/deployer
 go 1.24.0
 
 require (
+	github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.12
+	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30
 	github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.17.5
 	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
+	github.com/threefoldtech/zosbase v1.0.4
 )
 
 require (
@@ -12,7 +15,6 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.12 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/decred/base58 v1.0.5 // indirect
@@ -39,9 +41,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
-	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 // indirect
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5 // indirect
-	github.com/threefoldtech/zosbase v1.0.4 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect

--- a/threefold/deployer/main.go
+++ b/threefold/deployer/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"math/big"
 	"net"
 	"os"
 	"regexp"
@@ -14,6 +15,8 @@ import (
 	"strings"
 	"sync"
 
+	gsrpcTypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
+	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
@@ -37,6 +40,8 @@ const (
 	deploymentNameSuffix = "_dl_"
 	vmNameSuffix         = "_vm_"
 	networkNameSuffix    = "_net_"
+	githubOutputFormat   = "github"
+	textOutputFormat     = "text"
 )
 
 var prefixPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
@@ -53,6 +58,21 @@ type deployConfig struct {
 	prefix         string
 	maxConcurrency int
 	regionOrder    []string
+}
+
+type accountSnapshotConfig struct {
+	mnemonic string
+	network  string
+	format   string
+}
+
+type accountSnapshot struct {
+	address       string
+	freeTFT       string
+	reservedTFT   string
+	miscFrozenTFT string
+	freeFrozenTFT string
+	spendableTFT  string
 }
 
 type nodePlacement struct {
@@ -77,17 +97,43 @@ type deployJob struct {
 	assigned int
 }
 
+type substrateStorageGetter interface {
+	GetClient() (substrate.Conn, substrate.Meta, error)
+}
+
+type nodeDeployabilityChecker interface {
+	isOptedOutNodeAllowed(nodeID uint32) (bool, error)
+}
+
+type tfchainNodeDeployabilityChecker struct {
+	storageGetter      substrateStorageGetter
+	accountID          substrate.AccountID
+	isAllowedTwinAdmin bool
+}
+
 func main() {
-	cfg, err := parseCliArgs(os.Args[1:])
-	if err != nil {
+	if err := run(os.Args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return
 		}
 		log.Fatal(err)
 	}
-	if err := deploy(cfg); err != nil {
-		log.Fatal(err)
+}
+
+func run(args []string) error {
+	if len(args) > 0 && args[0] == "account-snapshot" {
+		cfg, err := parseAccountSnapshotCliArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		return printAccountSnapshot(cfg)
 	}
+
+	cfg, err := parseCliArgs(args)
+	if err != nil {
+		return err
+	}
+	return deploy(cfg)
 }
 
 // Parse and validate cli
@@ -160,6 +206,30 @@ func parseCliArgs(args []string) (deployConfig, error) {
 	return cfg, nil
 }
 
+func parseAccountSnapshotCliArgs(args []string) (accountSnapshotConfig, error) {
+	fs := flag.NewFlagSet("account-snapshot", flag.ContinueOnError)
+	cfg := accountSnapshotConfig{
+		network: "main",
+		format:  textOutputFormat,
+	}
+
+	fs.StringVar(&cfg.mnemonic, "mnemonic", "", "ThreeFold wallet mnemonic")
+	fs.StringVar(&cfg.network, "network", "main", "ThreeFold network")
+	fs.StringVar(&cfg.format, "format", textOutputFormat, "Output format: text or github")
+
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+	if strings.TrimSpace(cfg.mnemonic) == "" {
+		return cfg, fmt.Errorf("--mnemonic is required")
+	}
+	if cfg.format != textOutputFormat && cfg.format != githubOutputFormat {
+		return cfg, fmt.Errorf("--format must be %q or %q", textOutputFormat, githubOutputFormat)
+	}
+
+	return cfg, nil
+}
+
 // Orchestrates deployment of nodes, vms and networks as follows:
 // - Query for nodes that meet minimum capacity requirements, one region at a time, ordered by `regions` list
 // - Calculate total number of VMs that could be deployed to those nodes, based on our VM hardware requirements
@@ -181,11 +251,16 @@ func deploy(cfg deployConfig) error {
 	}
 	defer tf.Close()
 
+	checker, err := newNodeDeployabilityChecker(tf)
+	if err != nil {
+		return err
+	}
+
 	// Determine the number of VM placements available per region
 	candidates := make([]nodePlacement, 0)
 	totalCandidateCapacity := 0
 	for _, region := range cfg.regionOrder {
-		placements, err := placementsForRegion(ctx, tf, region, cfg)
+		placements, err := placementsForRegion(ctx, tf, region, cfg, checker)
 		if err != nil {
 			return err
 		}
@@ -379,7 +454,7 @@ func deployNode(ctx context.Context, tf deployer.TFPluginClient, cfg deployConfi
 // VM capacity based on the configured hardware requirements.
 //
 // Returns potential nodes sorted by descending capacity, then by node ID.
-func placementsForRegion(ctx context.Context, tf deployer.TFPluginClient, region string, cfg deployConfig) ([]nodePlacement, error) {
+func placementsForRegion(ctx context.Context, tf deployer.TFPluginClient, region string, cfg deployConfig, checker nodeDeployabilityChecker) ([]nodePlacement, error) {
 	regionFilter := region
 	freeMRU := cfg.vmMemGB * gib
 	freeSRU := cfg.vmDiskGB * gib
@@ -400,8 +475,38 @@ func placementsForRegion(ctx context.Context, tf deployer.TFPluginClient, region
 	}
 	log.Printf("region=%s candidates=%d (status=up free_mru>=%dGiB free_sru>=%dGiB)", region, len(nodes), cfg.vmMemGB, cfg.vmDiskGB)
 
+	placements, filteredOptOutNodes, err := placementsForNodes(region, nodes, cfg, checker)
+	if err != nil {
+		return nil, err
+	}
+
+	// Report only the nodes that passed the grid-proxy capacity filter but were
+	// excluded because TFChain would reject contract creation for this wallet.
+	if filteredOptOutNodes > 0 {
+		log.Printf("region=%s filtered_opted_out_nodes=%d", region, filteredOptOutNodes)
+	}
+
+	return placements, nil
+}
+
+func placementsForNodes(region string, nodes []types.Node, cfg deployConfig, checker nodeDeployabilityChecker) ([]nodePlacement, int, error) {
 	placements := make([]nodePlacement, 0, len(nodes))
+	filteredOptOutNodes := 0
 	for _, n := range nodes {
+		allowed, err := checker.isOptedOutNodeAllowed(uint32(n.NodeID))
+		if err != nil {
+			log.Printf("region=%s node_id=%d skipped: failed to check V3 billing opt-out status: %v", region, n.NodeID, err)
+			continue
+		}
+		if !allowed {
+			filteredOptOutNodes++
+			// V3 billing opt-out is a migration/admin path. Non-admin wallets
+			// cannot deploy on these nodes, so preflight must not count their
+			// capacity as usable.
+			log.Printf("region=%s node_id=%d skipped: node is V3 billing opted-out and wallet is not an allowed twin admin", region, n.NodeID)
+			continue
+		}
+
 		cap, byCPU, byMem, byDisk := capacityForNode(n, cfg)
 		if cap <= 0 {
 			continue
@@ -430,7 +535,7 @@ func placementsForRegion(ctx context.Context, tf deployer.TFPluginClient, region
 		log.Printf("region=%s node_id=%d node_capacity=%d limits(cpu=%d mem=%d disk=%d)", region, p.nodeID, p.capacity, p.byCPU, p.byMem, p.byDisk)
 	}
 
-	return placements, nil
+	return placements, filteredOptOutNodes, nil
 }
 
 // Calculate the maxmimum number of VMs that can be deployed to a single node,
@@ -458,4 +563,178 @@ func capacityForNode(n types.Node, cfg deployConfig) (int, int64, int64, int64) 
 		return 0, byCPU, byMem, byDisk
 	}
 	return int(minCap), byCPU, byMem, byDisk
+}
+
+func newNodeDeployabilityChecker(tf deployer.TFPluginClient) (nodeDeployabilityChecker, error) {
+	storageGetter, ok := tf.SubstrateConn.(substrateStorageGetter)
+	if !ok {
+		return nil, fmt.Errorf("substrate connection does not expose storage access")
+	}
+
+	accountID, err := substrate.FromAddress(tf.Identity.Address())
+	if err != nil {
+		return nil, fmt.Errorf("decode deployer account address: %w", err)
+	}
+
+	checker := &tfchainNodeDeployabilityChecker{
+		storageGetter: storageGetter,
+		accountID:     accountID,
+	}
+
+	checker.isAllowedTwinAdmin, err = checker.fetchAllowedTwinAdmin()
+	if err != nil {
+		return nil, fmt.Errorf("check allowed twin admin status: %w", err)
+	}
+	// This reports whether TFChain lists the deployer wallet as an allowed twin
+	// admin. Only those wallets may create contracts on nodes that farmers have
+	// opted out of normal V3 billing for migration.
+	if checker.isAllowedTwinAdmin {
+		log.Printf("deployer wallet is an allowed twin admin; V3 billing opted-out ThreeFold nodes are allowed")
+	} else {
+		log.Printf("deployer wallet is not an allowed twin admin; V3 billing opted-out ThreeFold nodes will be skipped")
+	}
+
+	return checker, nil
+}
+
+func (c *tfchainNodeDeployabilityChecker) isOptedOutNodeAllowed(nodeID uint32) (bool, error) {
+	optedOut, err := c.nodeHasV3BillingOptOut(nodeID)
+	if err != nil {
+		return false, err
+	}
+	return !optedOut || c.isAllowedTwinAdmin, nil
+}
+
+func (c *tfchainNodeDeployabilityChecker) nodeHasV3BillingOptOut(nodeID uint32) (bool, error) {
+	cl, meta, err := c.storageGetter.GetClient()
+	if err != nil {
+		return false, err
+	}
+
+	nodeIDBytes, err := substrate.Encode(nodeID)
+	if err != nil {
+		return false, fmt.Errorf("encode node id: %w", err)
+	}
+	key, err := gsrpcTypes.CreateStorageKey(meta, "TfgridModule", "NodeV3BillingOptOut", nodeIDBytes)
+	if err != nil {
+		return false, fmt.Errorf("create NodeV3BillingOptOut storage key: %w", err)
+	}
+
+	var optedOutAt gsrpcTypes.U64
+	ok, err := cl.RPC.State.GetStorageLatest(key, &optedOutAt)
+	if err != nil {
+		return false, fmt.Errorf("query NodeV3BillingOptOut storage: %w", err)
+	}
+	return ok, nil
+}
+
+func (c *tfchainNodeDeployabilityChecker) fetchAllowedTwinAdmin() (bool, error) {
+	cl, meta, err := c.storageGetter.GetClient()
+	if err != nil {
+		return false, err
+	}
+
+	key, err := gsrpcTypes.CreateStorageKey(meta, "TfgridModule", "AllowedTwinAdmins")
+	if err != nil {
+		return false, fmt.Errorf("create AllowedTwinAdmins storage key: %w", err)
+	}
+
+	var admins []substrate.AccountID
+	ok, err := cl.RPC.State.GetStorageLatest(key, &admins)
+	if err != nil {
+		return false, fmt.Errorf("query AllowedTwinAdmins storage: %w", err)
+	}
+	if !ok {
+		return false, nil
+	}
+
+	for _, admin := range admins {
+		if admin == c.accountID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func printAccountSnapshot(cfg accountSnapshotConfig) error {
+	pluginOpts := []deployer.PluginOpt{deployer.WithNetwork(cfg.network)}
+	tf, err := deployer.NewTFPluginClient(cfg.mnemonic, pluginOpts...)
+	if err != nil {
+		return fmt.Errorf("create tf plugin client: %w", err)
+	}
+	defer tf.Close()
+
+	balance, err := tf.SubstrateConn.GetBalance(tf.Identity)
+	if err != nil {
+		return fmt.Errorf("get account balance: %w", err)
+	}
+
+	snapshot := snapshotFromBalance(tf.Identity.Address(), balance)
+	switch cfg.format {
+	case githubOutputFormat:
+		fmt.Printf("address=%s\n", snapshot.address)
+		fmt.Printf("free_tft=%s\n", snapshot.freeTFT)
+		fmt.Printf("reserved_tft=%s\n", snapshot.reservedTFT)
+		fmt.Printf("misc_frozen_tft=%s\n", snapshot.miscFrozenTFT)
+		fmt.Printf("free_frozen_tft=%s\n", snapshot.freeFrozenTFT)
+		fmt.Printf("spendable_tft=%s\n", snapshot.spendableTFT)
+	case textOutputFormat:
+		fmt.Printf("address: %s\n", snapshot.address)
+		fmt.Printf("free_tft: %s\n", snapshot.freeTFT)
+		fmt.Printf("reserved_tft: %s\n", snapshot.reservedTFT)
+		fmt.Printf("misc_frozen_tft: %s\n", snapshot.miscFrozenTFT)
+		fmt.Printf("free_frozen_tft: %s\n", snapshot.freeFrozenTFT)
+		fmt.Printf("spendable_tft: %s\n", snapshot.spendableTFT)
+	default:
+		return fmt.Errorf("unsupported output format %q", cfg.format)
+	}
+
+	return nil
+}
+
+func snapshotFromBalance(address string, balance substrate.Balance) accountSnapshot {
+	return accountSnapshot{
+		address:       address,
+		freeTFT:       formatTFT(balance.Free),
+		reservedTFT:   formatTFT(balance.Reserved),
+		miscFrozenTFT: formatTFT(balance.MiscFrozen),
+		freeFrozenTFT: formatTFT(balance.FreeFrozen),
+		spendableTFT:  formatMicroTFT(spendableMicroTFT(balance)),
+	}
+}
+
+func spendableMicroTFT(balance substrate.Balance) *big.Int {
+	free := u128Int(balance.Free)
+	frozen := u128Int(balance.MiscFrozen)
+	if freeFrozen := u128Int(balance.FreeFrozen); freeFrozen.Cmp(frozen) > 0 {
+		frozen = freeFrozen
+	}
+
+	spendable := new(big.Int).Sub(free, frozen)
+	if spendable.Sign() < 0 {
+		return big.NewInt(0)
+	}
+	return spendable
+}
+
+func formatTFT(amount gsrpcTypes.U128) string {
+	return formatMicroTFT(u128Int(amount))
+}
+
+func formatMicroTFT(amount *big.Int) string {
+	unitsPerTFT := big.NewInt(substrate.TFT)
+	whole, fractional := new(big.Int), new(big.Int)
+	whole.QuoRem(amount, unitsPerTFT, fractional)
+	fractionalText := fractional.String()
+	if len(fractionalText) < 7 {
+		fractionalText = strings.Repeat("0", 7-len(fractionalText)) + fractionalText
+	}
+	return fmt.Sprintf("%s.%s", whole.String(), fractionalText)
+}
+
+func u128Int(amount gsrpcTypes.U128) *big.Int {
+	if amount.Int == nil {
+		return big.NewInt(0)
+	}
+	return new(big.Int).Set(amount.Int)
 }

--- a/threefold/deployer/main_test.go
+++ b/threefold/deployer/main_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	gsrpcTypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
+	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
+	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+)
+
+type fakeNodeDeployabilityChecker struct {
+	allowedByNodeID map[uint32]bool
+	errByNodeID     map[uint32]error
+}
+
+func (c fakeNodeDeployabilityChecker) isOptedOutNodeAllowed(nodeID uint32) (bool, error) {
+	if err, ok := c.errByNodeID[nodeID]; ok {
+		return false, err
+	}
+	if allowed, ok := c.allowedByNodeID[nodeID]; ok {
+		return allowed, nil
+	}
+	return true, nil
+}
+
+func TestPlacementsForNodesFiltersOptedOutNodes(t *testing.T) {
+	cfg := deployConfig{
+		vmCPU:    2,
+		vmMemGB:  8,
+		vmDiskGB: 20,
+	}
+	nodes := []types.Node{
+		testNode(1, 4, 16, 40),
+		testNode(2, 8, 32, 80),
+		testNode(3, 2, 8, 20),
+	}
+	checker := fakeNodeDeployabilityChecker{
+		allowedByNodeID: map[uint32]bool{
+			2: false,
+		},
+	}
+
+	placements, filtered, err := placementsForNodes("europe", nodes, cfg, checker)
+	if err != nil {
+		t.Fatalf("placementsForNodes returned error: %v", err)
+	}
+	if filtered != 1 {
+		t.Fatalf("filtered = %d, want 1", filtered)
+	}
+	if len(placements) != 2 {
+		t.Fatalf("len(placements) = %d, want 2", len(placements))
+	}
+
+	want := []nodePlacement{
+		{nodeID: 1, region: "europe", capacity: 2, byCPU: 2, byMem: 2, byDisk: 2},
+		{nodeID: 3, region: "europe", capacity: 1, byCPU: 1, byMem: 1, byDisk: 1},
+	}
+	for i, got := range placements {
+		if got != want[i] {
+			t.Fatalf("placements[%d] = %+v, want %+v", i, got, want[i])
+		}
+	}
+}
+
+func TestPlacementsForNodesSkipsDeployabilityLookupErrors(t *testing.T) {
+	cfg := deployConfig{
+		vmCPU:    2,
+		vmMemGB:  8,
+		vmDiskGB: 20,
+	}
+	checker := fakeNodeDeployabilityChecker{
+		errByNodeID: map[uint32]error{
+			42: errors.New("storage unavailable"),
+		},
+	}
+	nodes := []types.Node{
+		testNode(41, 4, 16, 40),
+		testNode(42, 4, 16, 40),
+		testNode(43, 2, 8, 20),
+	}
+
+	placements, filtered, err := placementsForNodes("americas", nodes, cfg, checker)
+	if err != nil {
+		t.Fatalf("placementsForNodes returned error: %v", err)
+	}
+	if filtered != 0 {
+		t.Fatalf("filtered = %d, want 0", filtered)
+	}
+	want := []nodePlacement{
+		{nodeID: 41, region: "americas", capacity: 2, byCPU: 2, byMem: 2, byDisk: 2},
+		{nodeID: 43, region: "americas", capacity: 1, byCPU: 1, byMem: 1, byDisk: 1},
+	}
+	if len(placements) != len(want) {
+		t.Fatalf("len(placements) = %d, want %d", len(placements), len(want))
+	}
+	for i, got := range placements {
+		if got != want[i] {
+			t.Fatalf("placements[%d] = %+v, want %+v", i, got, want[i])
+		}
+	}
+}
+
+func TestSnapshotFromBalanceFormatsTFTAndSpendableBalance(t *testing.T) {
+	snapshot := snapshotFromBalance("wallet-address", substrate.Balance{
+		Free:       testU128(1_000_000_001),
+		Reserved:   testU128(20_000_000),
+		MiscFrozen: testU128(30_000_000),
+		FreeFrozen: testU128(40_000_000),
+	})
+
+	if snapshot.address != "wallet-address" {
+		t.Fatalf("address = %q, want wallet-address", snapshot.address)
+	}
+	if snapshot.freeTFT != "100.0000001" {
+		t.Fatalf("freeTFT = %q, want 100.0000001", snapshot.freeTFT)
+	}
+	if snapshot.reservedTFT != "2.0000000" {
+		t.Fatalf("reservedTFT = %q, want 2.0000000", snapshot.reservedTFT)
+	}
+	if snapshot.miscFrozenTFT != "3.0000000" {
+		t.Fatalf("miscFrozenTFT = %q, want 3.0000000", snapshot.miscFrozenTFT)
+	}
+	if snapshot.freeFrozenTFT != "4.0000000" {
+		t.Fatalf("freeFrozenTFT = %q, want 4.0000000", snapshot.freeFrozenTFT)
+	}
+	if snapshot.spendableTFT != "96.0000001" {
+		t.Fatalf("spendableTFT = %q, want 96.0000001", snapshot.spendableTFT)
+	}
+}
+
+func TestSpendableMicroTFTDoesNotGoNegative(t *testing.T) {
+	spendable := spendableMicroTFT(substrate.Balance{
+		Free:       testU128(10),
+		FreeFrozen: testU128(20),
+	})
+	if spendable.Sign() != 0 {
+		t.Fatalf("spendable = %s, want 0", spendable.String())
+	}
+}
+
+func testNode(nodeID int, cru uint64, mruGiB uint64, sruGiB uint64) types.Node {
+	return types.Node{
+		NodeID: nodeID,
+		TotalResources: types.Capacity{
+			CRU: cru,
+			MRU: gridtypes.Unit(mruGiB) * gridtypes.Gigabyte,
+			SRU: gridtypes.Unit(sruGiB) * gridtypes.Gigabyte,
+		},
+	}
+}
+
+func testU128(value int64) gsrpcTypes.U128 {
+	return gsrpcTypes.U128{Int: big.NewInt(value)}
+}


### PR DESCRIPTION
### Summary

Fixes the ThreeFold scaled workflow so it skips nodes that TFChain would reject during contract creation. The workflow now also records the wallet balance before deploy and after cleanup, then reports the estimated cost and remaining weekly or monthly usage in the GitHub Actions summary.

Closes #649

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch
- [x] If this PR adds a new scenario, I have copied the [new scenario checklist](https://github.com/holochain/wind-tunnel/tree/main/docs/new-scenario-checklist.md) into this PR description and ticked off each applicable item

Notes: this does not add or change a scenario. The unchecked Nomad item needs the canonical scaled workflow to run after this branch is available on GitHub.

Manual validation note: the canonical scaled workflow run on 2026-07-03 confirms the original issue is fixed: V3 billing opted-out ThreeFold nodes are skipped before contract creation. The run still fails because current usable ThreeFold capacity is below the scenario demand: it requested 238 VMs and found 203 candidate slots after filtering. Even without the 20-node buffer it would need 218 slots, so this is a capacity limitation rather than the original allocation bug.
