### PR TITLE
ci: fix threefold mattermost notification secret name

### DIFF
--- a/.github/workflows/nomad-canonical-scaled.yaml
+++ b/.github/workflows/nomad-canonical-scaled.yaml
@@ -268,8 +268,8 @@ jobs:
         uses: holochain/actions/mattermost-notify@v1.12.0
         if: ${{ failure() }}
         with:
-          mattermost_personal_access_token: ${{ secrets.HOLOCHAIN_NOTIFIER_MATTERMOST_PERSONAL_ACCESS_TOKEN }}
-          channel_id: cxskxqhb37rtjp5w8myri3pdhh # HCF Tech channel
+          mattermost_personal_access_token: ${{ secrets.HOLOCHAIN_NOTIFIER_MATTERMOST_BOT_PERSONAL_ACCESS_TOKEN }}
+          channel_id: w3wnjwotkty9fbuo1qa5aqq86a # dev/wind-tunnel
           message: |-
             ALERT! A nomad canonical-scaled workflow run *failed* to cancel all Threefold node contracts.
             You may need to visit the [Threefold grid dashboard](https://dashboard.grid.tf/) to cancel all contracts manually.


### PR DESCRIPTION
### Summary

- Fixed the bot token name variable
- Made bot account to join channel
- Changed channel to `dev/wind-tunnnel`
- Tested the action by forcing run
- Asked Mamading to remove cloudflare robot checks for github calls

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch
- [x] If this PR adds a new scenario, I have copied the [new scenario checklist](https://github.com/holochain/wind-tunnel/tree/main/docs/new-scenario-checklist.md) into this PR description and ticked off each applicable item


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
