### PR TITLE
Update stable nixpkgs channel to 26.05

### DIFF
--- a/.github/actions/nomad/action.yaml
+++ b/.github/actions/nomad/action.yaml
@@ -70,7 +70,7 @@ runs:
         REQUIRED_NODES: ${{ steps.read-nomad-vars.outputs.required_nodes }}
         INCLUDE_THREEFOLD_NODE_POOL: ${{ inputs.include-threefold-node-pool }}
       run: |
-        nomad_bin="$(nix build --no-link --print-out-paths --impure --inputs-from . nixpkgsUnstable#nomad_1_11)/bin/nomad"
+        nomad_bin="$(nix build --no-link --print-out-paths --impure --inputs-from . nixpkgs#nomad_1_11)/bin/nomad"
         count_args=(--eligible-only)
         if [[ "$INCLUDE_THREEFOLD_NODE_POOL" == "true" ]]; then
           count_args+=(--include-threefold-node-pool)
@@ -172,7 +172,7 @@ runs:
         REQUIRED_NODES: ${{ steps.read-nomad-vars.outputs.required_nodes }}
         INCLUDE_THREEFOLD_NODE_POOL: ${{ inputs.include-threefold-node-pool }}
       run: |
-        nomad_bin="$(nix build --no-link --print-out-paths --impure --inputs-from . nixpkgsUnstable#nomad_1_11)/bin/nomad"
+        nomad_bin="$(nix build --no-link --print-out-paths --impure --inputs-from . nixpkgs#nomad_1_11)/bin/nomad"
         count_args=()
         if [[ "$INCLUDE_THREEFOLD_NODE_POOL" == "true" ]]; then
           count_args+=(--include-threefold-node-pool)
@@ -211,7 +211,7 @@ runs:
         set -exuo pipefail
         JOB_NAME="${{ inputs.job-name }}"
         nomad_rc=0
-        nomad_output=$(nix run --impure --inputs-from . nixpkgsUnstable#nomad_1_11 -- job plan -no-color ${{ inputs.nomad-job-variant-directory }}/jobs/${JOB_NAME}.nomad.hcl) || nomad_rc="$?"
+        nomad_output=$(nix run --impure --inputs-from . nixpkgs#nomad_1_11 -- job plan -no-color ${{ inputs.nomad-job-variant-directory }}/jobs/${JOB_NAME}.nomad.hcl) || nomad_rc="$?"
         echo "$nomad_output"
         if [ "$nomad_rc" -eq 255 ]; then
             echo "Planning Nomad job failed"
@@ -244,7 +244,7 @@ runs:
         set -exuo pipefail
         JOB_NAME="${{ inputs.job-name }}"
         nomad_rc=0
-        nomad_output=$(nix run --impure --inputs-from . nixpkgsUnstable#nomad_1_11 -- job run ${{ inputs.nomad-job-variant-directory }}/jobs/${JOB_NAME}.nomad.hcl) || nomad_rc="$?"
+        nomad_output=$(nix run --impure --inputs-from . nixpkgs#nomad_1_11 -- job run ${{ inputs.nomad-job-variant-directory }}/jobs/${JOB_NAME}.nomad.hcl) || nomad_rc="$?"
         if [ "$nomad_rc" -ne 0 ]; then
             echo "Nomad job submission failed with exit code $nomad_rc"
             echo "$nomad_output"

--- a/.github/workflows/nomad-canonical-scaled.yaml
+++ b/.github/workflows/nomad-canonical-scaled.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          nomad_bin="$(nix build --no-link --print-out-paths --impure --inputs-from . nixpkgsUnstable#nomad_1_11)/bin/nomad"
+          nomad_bin="$(nix build --no-link --print-out-paths --impure --inputs-from . nixpkgs#nomad_1_11)/bin/nomad"
           COUNT="$(NOMAD_BIN="$nomad_bin" ./nomad/scripts/count_eligible_nodes.sh --eligible-only --include-threefold-node-pool)"
 
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nomad-common-post.yaml
+++ b/.github/workflows/nomad-common-post.yaml
@@ -134,7 +134,7 @@ jobs:
         run: |
           for alloc_id in ${{ matrix.alloc_ids }}; do
             echo "Stopping allocation: $alloc_id"
-            nix run --impure --inputs-from . nixpkgsUnstable#nomad_1_11 -- alloc stop -detach "$alloc_id" || echo "Allocation $alloc_id could not be stopped"
+            nix run --impure --inputs-from . nixpkgs#nomad_1_11 -- alloc stop -detach "$alloc_id" || echo "Allocation $alloc_id could not be stopped"
           done
 
   run-summary:

--- a/flake.lock
+++ b/flake.lock
@@ -261,16 +261,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -243,22 +243,6 @@
         "type": "github"
       }
     },
-    "nixpkgsUnstable": {
-      "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1784432872,
@@ -282,7 +266,6 @@
         "git-hooks": "git-hooks",
         "holonix": "holonix",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgsUnstable": "nixpkgsUnstable",
         "rust-overlay": "rust-overlay_2"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-26.05";
 
-    nixpkgsUnstable.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     git-hooks = {
@@ -33,7 +31,6 @@
     , crane
     , rust-overlay
     , nixpkgs
-    , nixpkgsUnstable
     , ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {
@@ -53,10 +50,6 @@
         , ...
         }:
         let
-          unfreeUnstablePkgs = import nixpkgsUnstable {
-            inherit system;
-            config.allowUnfree = true;
-          };
           rustMod = inputs.flake-parts.lib.importApply ./nix/modules/rust.nix {
             inherit crane rust-overlay nixpkgs;
           };
@@ -148,6 +141,7 @@
 
           _module.args.pkgs = import nixpkgs {
             inherit system;
+            config.allowUnfreePredicate = pkg: builtins.elem (pkgs.lib.getName pkg) [ "nomad" ];
             overlays = [ rust-overlay.overlays.default ];
           };
 
@@ -212,7 +206,7 @@
                   pkgs.jq
                   pkgs.nodejs
                   pkgs.wrangler
-                  unfreeUnstablePkgs.nomad_1_11
+                  pkgs.nomad_1_11
                   inputs'.holonix.packages.hn-introspect
                 ];
 
@@ -475,7 +469,7 @@
               name = "validate-all-nomad-jobs";
               runtimeInputs = [
                 pkgs.gomplate
-                unfreeUnstablePkgs.nomad_1_11
+                pkgs.nomad_1_11
                 pkgs.getopt
               ];
               text = ''

--- a/flake.nix
+++ b/flake.nix
@@ -170,13 +170,6 @@
                 };
                 taplo.enable = true;
                 yamlfmt.enable = true;
-                check-summary-visualiser-html = {
-                  enable = true;
-                  name = "check-summary-visualiser-html";
-                  entry = "${config.packages.summary-visualiser-smoke-test}/bin/summary-visualiser-smoke-test";
-                  files = "^(summary-visualiser/.*|flake\.nix)$";
-                  pass_filenames = false;
-                };
               };
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for Holochain testing";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-26.05";
 
     nixpkgsUnstable.url = "github:nixos/nixpkgs?ref=nixos-unstable";
 
@@ -185,14 +185,13 @@
                 pkgs.netcat-gnu
                 pkgs.perl
                 pkgs.rustPlatform.bindgenHook
-                config.pre-commit.settings.enabledPackages
                 config.rustHelper.rust
                 customHolochain
                 inputs'.holonix.packages.lair-keystore
                 inputs'.holonix.packages.hc
                 inputs'.holonix.packages.bootstrap-srv
                 pkgs.cargo-nextest
-              ];
+              ] ++ config.pre-commit.settings.enabledPackages;
             in
             {
               default = pkgs.mkShell.override { stdenv = pkgs.clangStdenv; } {


### PR DESCRIPTION
### Summary

`nomad_1_11` is now in the stable 26.05 channel, so we no longer need the unstable channel if we switch to this. The main reason to do this is that x86-darwin is apparently no longer supported on the unstable channel, so either we need to move over to the stable channel, or we need to remove x86-darwin from `holonix.devShells.systems`.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch
- [x] If this PR adds a new scenario, I have copied the [new scenario checklist](https://github.com/holochain/wind-tunnel/tree/main/docs/new-scenario-checklist.md) into this PR description and ticked off each applicable item


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
