### PR TITLE
fix(ci): only reuse scenario releases from the same Holochain line

### DIFF
--- a/.github/actions/nomad/action.yaml
+++ b/.github/actions/nomad/action.yaml
@@ -104,20 +104,57 @@ runs:
           scenarios_common/**
           zomes/**
 
+    # Reuse a published scenario build only if it was built against the same
+    # Holochain minor line as the conductor this run deploys. Releases are cut
+    # from both `main` and the `main-*` maintenance branches, so "most recent
+    # release containing <scenario>.zip" is not on its own a safe choice: a
+    # 0.6 run would happily pick up a 0.7 pre-release built from `main`, and
+    # every agent would then fail against the 0.6 conductor, producing a run
+    # with no metrics at all.
     - name: Check if release exists
       id: check-release
       if: steps.needs-rebuild.outputs.any_changed != 'true' && inputs.force-rebuild != 'true'
       shell: bash
       env:
         SCENARIO_NAME: ${{ steps.read-nomad-vars.outputs.scenario_name }}
+        HOLOCHAIN_BIN_URL: ${{ inputs.holochain-bin-url }}
         GH_TOKEN: ${{ github.token }}
       run: |-
-        TAG=$(gh api "/repos/${GITHUB_REPOSITORY}/releases?per_page=10" \
+        set -euo pipefail
+
+        # Reduce a Holochain version to its minor line, e.g. 0.7.0-rc.1 -> 0.7
+        holochain_line() { sed -nE 's/^([0-9]+\.[0-9]+).*/\1/p'; }
+
+        # The conductor being deployed is the ground truth for compatibility.
+        WANT_LINE="$(basename "$(dirname "$HOLOCHAIN_BIN_URL")" | sed -E 's/^holochain-//' | holochain_line)"
+        if [[ -z "$WANT_LINE" ]]; then
+          echo "::error::Could not determine the Holochain version from holochain-bin-url '${HOLOCHAIN_BIN_URL}'"
+          exit 1
+        fi
+        echo "Conductor Holochain line: ${WANT_LINE}"
+
+        mapfile -t CANDIDATES < <(gh api "/repos/${GITHUB_REPOSITORY}/releases?per_page=30" \
           | jq -r --arg name "${SCENARIO_NAME}.zip" \
-            '.[] | select(any(.assets[]; .name == $name)) | .tag_name' \
-          | head -1)
+            '.[] | select(any(.assets[]?; .name == $name)) | .tag_name')
+
+        # Releases are newest first, so the first line match is the freshest
+        # build that can actually run against this conductor.
+        TAG=""
+        for candidate in ${CANDIDATES[@]+"${CANDIDATES[@]}"}; do
+          got_line="$(gh api "/repos/${GITHUB_REPOSITORY}/contents/Cargo.toml?ref=${candidate}" \
+              -H "Accept: application/vnd.github.raw" 2>/dev/null \
+            | grep -m1 -oP '^\s*holochain_zome_types\s*=.*version\s*=\s*"\K[^"]+' \
+            | holochain_line)" || true
+          if [[ "$got_line" == "$WANT_LINE" ]]; then
+            TAG="$candidate"
+            echo "Accepted release tag '${TAG}' (Holochain ${got_line})"
+            break
+          fi
+          echo "Rejected release tag '${candidate}' (Holochain ${got_line:-unknown}, need ${WANT_LINE})"
+        done
+
         if [[ -z "$TAG" ]]; then
-          echo "::warning::No release found containing ${SCENARIO_NAME}.zip, falling back to a rebuild"
+          echo "::warning::No release found containing ${SCENARIO_NAME}.zip built for Holochain ${WANT_LINE}, falling back to a rebuild"
           echo "found=false" >> "$GITHUB_OUTPUT"
         else
           echo "Found release tag '$TAG' containing ${SCENARIO_NAME}.zip"


### PR DESCRIPTION
## Problem

The nomad action skips rebuilding a scenario by downloading `<scenario>.zip` from the most recent release that contains it. Nothing tied that choice to a Holochain line.

Releases are cut from `main` **and** the `main-*` maintenance branches, and every release reports `target_commitish: main`, so that field cannot tell them apart.

Run [30444971126](https://github.com/holochain/wind-tunnel/actions/runs/30444971126) on `main-0.6` hit this. The `main-cb94fb5` pre-release (Holochain 0.7.0-rc) had been published 16 minutes earlier, so 26 of 30 scenarios downloaded 0.7-rc binaries and ran them against the 0.6.3 conductor the workflow deploys. No agent work succeeded, nothing reached InfluxDB, and the summariser reported:

```
[WARN holochain_summariser] 25 out of 27 summaries failed:
        context: "summarize_first_call"
        source: NoSeriesInResult { table: "wt.instruments.operation_duration", ... }
```

The published summary contained two scenarios — `unyt_chain_transaction` (resolved to `v0.7.1`, a 0.6-line tag) and `unyt_swap` (brand new, so no release had it and it was rebuilt). Because `ignore-summary-errors: true`, the workflow reported success.

## Fix

Gate release reuse on the Holochain minor line. It is derived from the `holochain-bin-url` input — the conductor actually deployed — and compared against `holochain_zome_types` in the candidate tag's `Cargo.toml`. Candidates are walked newest-first and the first line match wins.

```
Conductor Holochain line: 0.6
Rejected release tag 'main-cb94fb5' (Holochain 0.7, need 0.6)
Accepted release tag 'v0.7.1' (Holochain 0.6)
```

This needs no changes to the publish workflows and no new release metadata. `holochain_zome_types` tracks the Holochain workspace version exactly, and its declaration format is unchanged across every tag back to `v0.5.0`.

Every failure path falls through to the existing rebuild, which is correct-but-slower. The one hard failure is an unparseable `holochain-bin-url`, because that is the basis for the whole comparison.

## Verification

The step's script was extracted from the YAML and driven with live `gh` API calls against real release data:

| Case | Expected | Result |
| --- | --- | --- |
| `write_read` on 0.6 line | reject `main-cb94fb5`, take `v0.7.1` | pass |
| `write_read` on 0.7 line | take `main-cb94fb5` | pass |
| `unyt_swap`, no release anywhere | rebuild | pass |
| `unyt_chain_transaction` on 0.7 line | reject both 0.6 tags, rebuild | pass |
| `unyt_chain_transaction` on 0.6 line | still reuse `v0.7.1` | pass |
| malformed `holochain-bin-url` | exit 1 | pass |
| URL with no directory component | exit 1 | pass |

Case 4 closes the reverse direction: a `main` run can no longer fall back to a 0.6-line tag when the current pre-release is missing a scenario.

`yamlfmt -lint` is clean. The commit cherry-picks onto `main-0.6` without conflicts, verified in a scratch worktree.

## Not covered here

`ignore-summary-errors: true` is what let this run report green. Flipping it to `false` would fail a run on any single flaky scenario, so it needs its own change — surfacing a dropped-scenario count in the job summary would be the smaller fix. Deliberately out of scope.