### PR TITLE
Fix countersigning imports and run duration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,10 +168,7 @@ holochain_conductor_api = { version = "0.7.0" }
 holochain_conductor_config = { version = "0.7.0" }
 holochain_serialized_bytes = "0.0.57"
 holochain_websocket = { version = "0.7.0" }
-hdk = { version = "0.7.0", features = [
-  "unstable-functions",
-  "unstable-countersigning",
-] }
+hdk = { version = "0.7.0", features = ["unstable-functions"] }
 hdi = { version = "0.8.0", features = ["unstable-functions"] }
 
 # Deps for Kitsune

--- a/happ_builder/src/builder.rs
+++ b/happ_builder/src/builder.rs
@@ -33,6 +33,7 @@ impl HappBuilder<'_> {
     /// The built hApp(s) will appear as `/happs/<scenario-name>/<happ-name>.happ` from the project root.
     pub fn build_happs(&self) -> anyhow::Result<()> {
         self.print_rerun_for_package(&self.options.manifest_dir);
+        self.print_rerun_for_workspace();
 
         let mut built_dnas = vec![];
 
@@ -238,6 +239,16 @@ impl HappBuilder<'_> {
         }
 
         Ok(wasm_path)
+    }
+
+    /// Ensure the build script is re-run when the workspace manifest or lockfile changes.
+    fn print_rerun_for_workspace(&self) {
+        for file in ["Cargo.toml", "Cargo.lock"] {
+            let path = self.options.workspace_root.join(file);
+            if path.exists() {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
+        }
     }
 
     fn print_rerun_for_package(&self, package_dir: &Path) {

--- a/happ_builder/src/options.rs
+++ b/happ_builder/src/options.rs
@@ -10,6 +10,7 @@ pub struct HappManagerOptions {
     pub zomes_dir: PathBuf,
     pub dna_target_dir: PathBuf,
     pub happ_target_dir: PathBuf,
+    pub workspace_root: PathBuf,
 }
 
 impl Default for HappManagerOptions {
@@ -20,6 +21,7 @@ impl Default for HappManagerOptions {
         let zomes_dir = manifest_dir.join("../../zomes");
         let dna_target_dir = manifest_dir.join("../../dnas");
         let happ_target_dir = manifest_dir.join("../../happs");
+        let workspace_root = manifest_dir.join("../..");
 
         HappManagerOptions {
             package_name: env::var("CARGO_PKG_NAME").expect("CARGO_PKG_NAME not set"),
@@ -29,6 +31,7 @@ impl Default for HappManagerOptions {
             zomes_dir,
             dna_target_dir,
             happ_target_dir,
+            workspace_root,
         }
     }
 }
@@ -73,6 +76,12 @@ impl HappManagerOptions {
     /// Set `happ_target_dir` option
     pub fn happ_target_dir(mut self, path: PathBuf) -> Self {
         self.happ_target_dir = path;
+        self
+    }
+
+    /// Set `workspace_root` option
+    pub fn workspace_root(mut self, path: PathBuf) -> Self {
+        self.workspace_root = path;
         self
     }
 }

--- a/happ_builder/tests/fetch_integration.rs
+++ b/happ_builder/tests/fetch_integration.rs
@@ -39,6 +39,7 @@ fn should_fetch_happ() {
         zomes_dir: tempdir.path().join("zomes"),
         dna_target_dir: tempdir.path().join("dnas"),
         happ_target_dir: happ_target_dir.clone(),
+        workspace_root: tempdir.path().to_path_buf(),
     };
 
     let manager = HappManager::from(options);
@@ -76,6 +77,7 @@ fn should_refetch_if_hash_mismatch() {
         zomes_dir: tempdir.path().join("zomes"),
         dna_target_dir: tempdir.path().join("dnas"),
         happ_target_dir: happ_target_dir.clone(),
+        workspace_root: tempdir.path().to_path_buf(),
     };
 
     let manager = HappManager::from(options);
@@ -116,6 +118,7 @@ fn should_fail_if_hash_mismatch_manifest() {
         zomes_dir: tempdir.path().join("zomes"),
         dna_target_dir: tempdir.path().join("dnas"),
         happ_target_dir: happ_target_dir.clone(),
+        workspace_root: tempdir.path().to_path_buf(),
     };
 
     let manager = HappManager::from(options);

--- a/nomad/scripts/ci_allocs.sh
+++ b/nomad/scripts/ci_allocs.sh
@@ -108,14 +108,14 @@ function generate_run_summary() {
           --arg behaviours "${behaviours:-}" \
           --arg wind_tunnel_version "$wind_tunnel_version" \
           --argjson holochain_build_info "$holochain_build_info" \
-          --argjson duration "$duration" '
+          --argjson run_duration "$duration" '
             # Split behaviours field; default to [""]
             ($behaviours | if . == "" then [""] else split(" ") end) as $bs
             | {
                 run_id: $run_id,
                 scenario_name: $scenario_name,
                 started_at: $started_at,
-                duration: $duration,
+                run_duration: $run_duration,
                 assigned_behaviours: (reduce $bs[] as $b ({}; .[$b] += 1)),
                 peer_count: $peer_count,
                 peer_end_count: $peer_end_count,

--- a/zomes/countersigning/coordinator/Cargo.toml
+++ b/zomes/countersigning/coordinator/Cargo.toml
@@ -11,7 +11,8 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-hdk = { workspace = true }
+# This zome is the one place that needs the countersigning host functions.
+hdk = { workspace = true, features = ["unstable-countersigning"] }
 countersigning_integrity = { workspace = true }
 
 [lints]


### PR DESCRIPTION
### Summary

When we dropped countersigning from unstable binary builds for Holochain, we broke all the Wind Tunnel scenarios because they enable countersigning for the HDK which then forces it to be present it on the host.

Also noticed a wrong field name in use in the ci-allocs script that would result in missing duration information for the summariser which is an important part of the filtering query that makes querying efficient.

Closes https://github.com/holochain/wind-tunnel/issues/702

### TODO:

- [ ] All code changes are reflected in docs, including module-level docs
- [ ] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [ ] I ran the Nomad CI workflow successfully on my branch
- [ ] If this PR adds a new scenario, I have copied the [new scenario checklist](https://github.com/holochain/wind-tunnel/tree/main/docs/new-scenario-checklist.md) into this PR description and ticked off each applicable item


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
