### PR TITLE
fix(ci): unbreak summary publishing for canonical-scaled runs

### DIFF
--- a/.github/workflows/nomad-canonical-scaled.yaml
+++ b/.github/workflows/nomad-canonical-scaled.yaml
@@ -162,6 +162,11 @@ jobs:
     needs: run-scenarios
     uses: ./.github/workflows/nomad-common-post.yaml
     if: ${{ always() }}
+    # The workflow-level `permissions` above caps every job at `contents: read`,
+    # which makes the summary job's push to `gh-pages` fail with a 403. Raise it
+    # here so the summary visualiser and runs list can be published.
+    permissions:
+      contents: write
     secrets:
       NOMAD_ACCESS_TOKEN: ${{ secrets.NOMAD_ACCESS_TOKEN }}
       INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}

--- a/.github/workflows/nomad-common-post.yaml
+++ b/.github/workflows/nomad-common-post.yaml
@@ -199,7 +199,21 @@ jobs:
           HOLOCHAIN_BIN_URL: ${{ inputs.holochain-bin-url }}
         run: |
           nix develop --command ./nomad/scripts/ci_allocs.sh generate_run_summary alloc_ids.csv "$RUN_SUMMARY_PATH"
-          cat "$RUN_SUMMARY_PATH" >> "$GITHUB_STEP_SUMMARY"
+
+          # The run summary holds one line per agent, so dumping it whole blows past the
+          # 1MB step summary limit and GitHub discards the lot. Emit one row per run
+          # instead. Repeated scenario names here mean job variants that the summariser
+          # will collapse into a single report, because it keys on scenario name and
+          # fingerprint rather than run id.
+          {
+            echo "### Run summary"
+            echo
+            echo "| Scenario | Run ID | Duration (s) | Peers at start | Peers at end |"
+            echo "| --- | --- | --- | ---: | ---: |"
+            jq -s -r 'unique_by(.run_id) | sort_by(.scenario_name, .run_id)[]
+              | "| \(.scenario_name) | \(.run_id) | \(.run_duration // "-") | \(.peer_count) | \(.peer_end_count) |"' \
+              "$RUN_SUMMARY_PATH"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cache summariser
         uses: actions/cache@v6


### PR DESCRIPTION
## Summary

Two independent failures in the `Generate a summary of all scenarios` job, both seen on [run 33072482790](https://github.com/holochain/wind-tunnel/actions/runs/33072482790/job/98630186742).

- **`gh-pages` push denied.** `nomad-canonical-scaled.yaml` declares a workflow-level `permissions: contents: read`, added in 1cf7ebf0 alongside an unrelated ThreeFold change. That caps every job in the workflow, and a called workflow can only narrow what the caller grants — so the reusable `nomad-common-post.yaml` summary job ran with a read-only token and `git push origin gh-pages` returned 403. Granted `contents: write` on the `post-run-scenarios` call; all other scopes remain `none`, exactly as before.

  This is not a one-off: every canonical-scaled run since the permissions block landed has failed at the same step (checked 2026-08-21 and 2026-08-14). `nomad-canonical.yaml` and `nomad-demo.yaml` are unaffected because they declare no `permissions` block and inherit the repo default.

- **Step summary discarded.** `cat "$RUN_SUMMARY_PATH" >> "$GITHUB_STEP_SUMMARY"` wrote one line per agent — 2403 lines, 1.78MB for a 150-agent run — and GitHub aborted the upload against its 1MB cap, losing the whole step summary. Emits one row per run instead (1715 bytes for the same run).

## Notes

The run data itself was never lost. It has been recovered from the `run_summary` artifact plus InfluxDB and is published in #710, which reproduces CI's output exactly — the failed job's commit reported `2 files changed, 71793 insertions(+)`, and so does the recovery.

Worth flagging separately: that run produced 17 run_ids but only 14 selected summaries. Job variants that differ only in behaviour node counts (`--high_zero`) hash to the same `RunSummary::fingerprint()`, so the summariser collapses each pair and keeps the later one. Not addressed here — fixing it changes fingerprints repo-wide and invalidates the summariser snapshot test data.
