### PR TITLE
ci: update the scaled Nomad cron schedule to Thursday

### DIFF
--- a/.github/workflows/nomad-canonical-scaled.yaml
+++ b/.github/workflows/nomad-canonical-scaled.yaml
@@ -9,7 +9,7 @@ on:
         required: false
         default: false
   schedule:
-    - cron: "0 0 * * 5" # Run Nomad workflow at 00:00 on Fridays
+    - cron: "0 0 * * 4" # Run Nomad workflow at 00:00 on Thursdays
 
 concurrency:
   group: nomad # This is the same group as all other Nomad workflows


### PR DESCRIPTION
### Summary

Just change the cron job schedule to run on Thursday morning, so we have more time to notice failed runs.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs
- [x] All new/edited/removed scenarios are reflected in summary visualiser tool (see [checklist](https://github.com/holochain/wind-tunnel/tree/main/summary-visualiser/README.md#maintenance))
- [x] I ran the Nomad CI workflow successfully on my branch
- [x] If this PR adds a new scenario, I have copied the [new scenario checklist](https://github.com/holochain/wind-tunnel/tree/main/docs/new-scenario-checklist.md) into this PR description and ticked off each applicable item


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_
