### PR TITLE
build: pin kitsune2 simultaneous-open fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,8 +1919,8 @@ dependencies = [
  "happ_builder",
  "holochain_types",
  "holochain_wind_tunnel_runner",
- "kitsune2_api",
- "kitsune2_core",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "timed_and_validated_integrity",
 ]
 
@@ -2443,7 +2443,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_util",
  "holochain_wasmer_common",
- "kitsune2_api",
+ "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "must_future",
  "rand 0.9.5",
  "schemars 0.9.0",
@@ -2470,7 +2470,7 @@ dependencies = [
  "holochain_types",
  "holochain_websocket",
  "holochain_zome_types",
- "kitsune2_api",
+ "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lair_keystore_api",
  "parking_lot",
  "rand 0.8.7",
@@ -2490,7 +2490,7 @@ dependencies = [
  "holochain_types",
  "holochain_websocket",
  "holochain_zome_types",
- "kitsune2_api",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "url",
  "wind_tunnel_core",
  "wind_tunnel_instruments",
@@ -2512,8 +2512,8 @@ dependencies = [
  "holochain_util",
  "holochain_zome_types",
  "indexmap 2.14.0",
- "kitsune2_api",
- "kitsune2_core",
+ "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune2_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nanoid 0.4.0",
  "num_cpus",
  "schemars 0.9.0",
@@ -2732,7 +2732,7 @@ dependencies = [
  "holochain_zome_types",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "kitsune2_api",
+ "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mr_bundle",
  "must_future",
  "nanoid 0.4.0",
@@ -2828,8 +2828,8 @@ dependencies = [
  "holochain_conductor_api",
  "holochain_conductor_config",
  "holochain_types",
- "kitsune2_api",
- "kitsune2_core",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "log",
  "rand 0.9.5",
  "serde",
@@ -3699,12 +3699,11 @@ dependencies = [
 [[package]]
 name = "kitsune2"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7d36e37fa43ab9c1929f7696f25ff24cb5f2a7a0bf9af89755111bc9a8efee"
+source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "bytes",
- "kitsune2_api",
- "kitsune2_core",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "kitsune2_gossip",
  "kitsune2_transport_iroh",
  "serde",
@@ -3728,13 +3727,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune2_api"
+version = "0.5.1"
+source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "prost 0.14.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "kitsune2_bootstrap_client"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26b07b724567aade174c12e618830268d1bce71b9e74349f1874e785416ad64"
 dependencies = [
  "base64 0.22.1",
- "kitsune2_api",
+ "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_json",
+ "tracing",
+ "ureq",
+ "url",
+]
+
+[[package]]
+name = "kitsune2_bootstrap_client"
+version = "0.5.1"
+source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
+dependencies = [
+ "base64 0.22.1",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "serde",
  "serde_json",
  "tracing",
@@ -3745,8 +3774,7 @@ dependencies = [
 [[package]]
 name = "kitsune2_bootstrap_srv"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d87ece6c9e394a355fd4170fa2935087c4eaf71ce7e3b7aa26b06d16d6b3ac9"
+source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "async-channel",
  "axum",
@@ -3789,8 +3817,28 @@ dependencies = [
  "bytes",
  "ed25519-dalek 2.2.0",
  "futures",
- "kitsune2_api",
- "kitsune2_bootstrap_client",
+ "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune2_bootstrap_client 0.5.0",
+ "prost 0.14.4",
+ "rand 0.8.7",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "kitsune2_core"
+version = "0.5.1"
+source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "ed25519-dalek 2.2.0",
+ "futures",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_bootstrap_client 0.5.1",
  "prost 0.14.4",
  "rand 0.8.7",
  "serde",
@@ -3802,25 +3850,23 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_dht"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788c8ed516c8251a7fb5e5d9815ad0b8392729198ad2793e6f1a6e3e682835a7"
+version = "0.5.1"
+source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "bytes",
- "kitsune2_api",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "tracing",
 ]
 
 [[package]]
 name = "kitsune2_gossip"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bd4f31c1112b7352386b7b7775e37075c80004aeeb374cc4c71e42407dab79"
+source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "bytes",
  "futures",
- "kitsune2_api",
- "kitsune2_core",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "kitsune2_dht",
  "prost 0.14.4",
  "rand 0.8.7",
@@ -3834,14 +3880,13 @@ dependencies = [
 [[package]]
 name = "kitsune2_transport_iroh"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c962f108997f98f9b62eabb21de809b5853c9866242c02cfb267068603acba"
+source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "iroh",
- "kitsune2_api",
- "kitsune2_bootstrap_client",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_bootstrap_client 0.5.1",
  "n0-watcher",
  "serde",
  "tokio",
@@ -3857,9 +3902,9 @@ dependencies = [
  "bytes",
  "env_logger",
  "kitsune2",
- "kitsune2_api",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "kitsune2_bootstrap_srv",
- "kitsune2_core",
+ "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "kitsune2_gossip",
  "kitsune2_transport_iroh",
  "log",
@@ -9497,8 +9542,8 @@ dependencies = [
  "holochain_types",
  "holochain_wind_tunnel_runner",
  "holochain_zome_types",
- "kitsune2_api",
- "kitsune2_core",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "log",
 ]
 
@@ -9511,8 +9556,8 @@ dependencies = [
  "holochain_types",
  "holochain_wind_tunnel_runner",
  "holochain_zome_types",
- "kitsune2_api",
- "kitsune2_core",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "log",
  "rand 0.9.5",
  "tokio",
@@ -9704,8 +9749,8 @@ dependencies = [
  "happ_builder",
  "holochain_types",
  "holochain_wind_tunnel_runner",
- "kitsune2_api",
- "kitsune2_core",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "timed_integrity",
 ]
 
@@ -9717,8 +9762,8 @@ dependencies = [
  "happ_builder",
  "holochain_types",
  "holochain_wind_tunnel_runner",
- "kitsune2_api",
- "kitsune2_core",
+ "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
  "timed_and_validated_integrity",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3698,9 +3698,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed54db66ff85d8b7b8a88658438ef94fdd5d1885a4557db477cf63f4dff3d0c"
+checksum = "5d7d36e37fa43ab9c1929f7696f25ff24cb5f2a7a0bf9af89755111bc9a8efee"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -3712,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35592adcc191d30f24edff73da41ea697b692caf5397aa6b640800ed3523c117"
+checksum = "a5d3591317c71d8f51d19f693acbc277b9b3e9fbc46f33c3827fefc953b1b9f2"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3744,9 +3744,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29026f6f9e805c1c06a36b7f93687cbb11c6f537c2b1c418131e9ec164b50b6d"
+checksum = "8d87ece6c9e394a355fd4170fa2935087c4eaf71ce7e3b7aa26b06d16d6b3ac9"
 dependencies = [
  "async-channel",
  "axum",
@@ -3781,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1207d2f463f5e0b136ae918cc665f042abe78a21c63e7d5f6ed4faf10fc46e"
+checksum = "7ec85ef7191e2229c2c44cc47b6fb3ce2429fae4b92b2d406e63a7e0a1fb4b6d"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3813,9 +3813,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76215d8944011a4ae3e897cc45e33314f071f6c704b8e694df9204b39c6d6d43"
+checksum = "01bd4f31c1112b7352386b7b7775e37075c80004aeeb374cc4c71e42407dab79"
 dependencies = [
  "bytes",
  "futures",
@@ -3833,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_iroh"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564abdfe9800443a58e3bf6985b7950c1ff2af2158ac4a22a2278ea4bcc9e31d"
+checksum = "90c962f108997f98f9b62eabb21de809b5853c9866242c02cfb267068603acba"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,8 +1919,8 @@ dependencies = [
  "happ_builder",
  "holochain_types",
  "holochain_wind_tunnel_runner",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
+ "kitsune2_core",
  "timed_and_validated_integrity",
 ]
 
@@ -2443,7 +2443,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_util",
  "holochain_wasmer_common",
- "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune2_api",
  "must_future",
  "rand 0.9.5",
  "schemars 0.9.0",
@@ -2470,7 +2470,7 @@ dependencies = [
  "holochain_types",
  "holochain_websocket",
  "holochain_zome_types",
- "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune2_api",
  "lair_keystore_api",
  "parking_lot",
  "rand 0.8.7",
@@ -2490,7 +2490,7 @@ dependencies = [
  "holochain_types",
  "holochain_websocket",
  "holochain_zome_types",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
  "url",
  "wind_tunnel_core",
  "wind_tunnel_instruments",
@@ -2512,8 +2512,8 @@ dependencies = [
  "holochain_util",
  "holochain_zome_types",
  "indexmap 2.14.0",
- "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kitsune2_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune2_api",
+ "kitsune2_core",
  "nanoid 0.4.0",
  "num_cpus",
  "schemars 0.9.0",
@@ -2732,7 +2732,7 @@ dependencies = [
  "holochain_zome_types",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune2_api",
  "mr_bundle",
  "must_future",
  "nanoid 0.4.0",
@@ -2828,8 +2828,8 @@ dependencies = [
  "holochain_conductor_api",
  "holochain_conductor_config",
  "holochain_types",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
+ "kitsune2_core",
  "log",
  "rand 0.9.5",
  "serde",
@@ -3702,8 +3702,8 @@ version = "0.5.1"
 source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "bytes",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
+ "kitsune2_core",
  "kitsune2_gossip",
  "kitsune2_transport_iroh",
  "serde",
@@ -3712,23 +3712,6 @@ dependencies = [
 [[package]]
 name = "kitsune2_api"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d3591317c71d8f51d19f693acbc277b9b3e9fbc46f33c3827fefc953b1b9f2"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures",
- "prost 0.14.4",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "kitsune2_api"
-version = "0.5.1"
 source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "base64 0.22.1",
@@ -3744,26 +3727,11 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26b07b724567aade174c12e618830268d1bce71b9e74349f1874e785416ad64"
-dependencies = [
- "base64 0.22.1",
- "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_json",
- "tracing",
- "ureq",
- "url",
-]
-
-[[package]]
-name = "kitsune2_bootstrap_client"
 version = "0.5.1"
 source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "base64 0.22.1",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
  "serde",
  "serde_json",
  "tracing",
@@ -3810,35 +3778,14 @@ dependencies = [
 [[package]]
 name = "kitsune2_core"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec85ef7191e2229c2c44cc47b6fb3ce2429fae4b92b2d406e63a7e0a1fb4b6d"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "ed25519-dalek 2.2.0",
- "futures",
- "kitsune2_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kitsune2_bootstrap_client 0.5.0",
- "prost 0.14.4",
- "rand 0.8.7",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "kitsune2_core"
-version = "0.5.1"
 source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "ed25519-dalek 2.2.0",
  "futures",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_bootstrap_client 0.5.1",
+ "kitsune2_api",
+ "kitsune2_bootstrap_client",
  "prost 0.14.4",
  "rand 0.8.7",
  "serde",
@@ -3854,7 +3801,7 @@ version = "0.5.1"
 source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5#5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5"
 dependencies = [
  "bytes",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
  "tracing",
 ]
 
@@ -3865,8 +3812,8 @@ source = "git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20
 dependencies = [
  "bytes",
  "futures",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
+ "kitsune2_core",
  "kitsune2_dht",
  "prost 0.14.4",
  "rand 0.8.7",
@@ -3885,8 +3832,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "iroh",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_bootstrap_client 0.5.1",
+ "kitsune2_api",
+ "kitsune2_bootstrap_client",
  "n0-watcher",
  "serde",
  "tokio",
@@ -3902,9 +3849,9 @@ dependencies = [
  "bytes",
  "env_logger",
  "kitsune2",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
  "kitsune2_bootstrap_srv",
- "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_core",
  "kitsune2_gossip",
  "kitsune2_transport_iroh",
  "log",
@@ -9542,8 +9489,8 @@ dependencies = [
  "holochain_types",
  "holochain_wind_tunnel_runner",
  "holochain_zome_types",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
+ "kitsune2_core",
  "log",
 ]
 
@@ -9556,8 +9503,8 @@ dependencies = [
  "holochain_types",
  "holochain_wind_tunnel_runner",
  "holochain_zome_types",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
+ "kitsune2_core",
  "log",
  "rand 0.9.5",
  "tokio",
@@ -9749,8 +9696,8 @@ dependencies = [
  "happ_builder",
  "holochain_types",
  "holochain_wind_tunnel_runner",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
+ "kitsune2_core",
  "timed_integrity",
 ]
 
@@ -9762,8 +9709,8 @@ dependencies = [
  "happ_builder",
  "holochain_types",
  "holochain_wind_tunnel_runner",
- "kitsune2_api 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
- "kitsune2_core 0.5.1 (git+https://github.com/holochain/kitsune2?rev=5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5)",
+ "kitsune2_api",
+ "kitsune2_core",
  "timed_and_validated_integrity",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,16 @@ validated_integrity = { path = "./zomes/validated/integrity" }
 agent_activity_integrity = { path = "./zomes/agent_activity/integrity" }
 validated_must_get_agent_activity_integrity = { path = "./zomes/validated_must_get_agent_activity/integrity" }
 
+[patch.crates-io]
+kitsune2 = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_api = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_bootstrap_client = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_bootstrap_srv = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_core = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_dht = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_gossip = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_transport_iroh = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+
 [workspace.lints.rust]
 unsafe_code = "forbid"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,14 +172,14 @@ hdk = { version = "0.7.0", features = ["unstable-functions"] }
 hdi = { version = "0.8.0", features = ["unstable-functions"] }
 
 # Deps for Kitsune
-kitsune2 = { version = "0.5.0", default-features = false, features = [
+kitsune2 = { version = "0.5.1", default-features = false, features = [
   "transport-iroh",
 ] }
-kitsune2_api = "0.5.0"
-kitsune2_core = "0.5.0"
-kitsune2_gossip = "0.5.0"
-kitsune2_transport_iroh = { version = "0.5.0", default-features = false }
-kitsune2_bootstrap_srv = { version = "0.5.0", default-features = false }
+kitsune2_api = "0.5.1"
+kitsune2_bootstrap_srv = { version = "0.5.1", default-features = false }
+kitsune2_core = "0.5.1"
+kitsune2_gossip = "0.5.1"
+kitsune2_transport_iroh = { version = "0.5.1", default-features = false }
 
 # Deps for Unyt
 # rave_engine = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,14 +172,14 @@ hdk = { version = "0.7.0", features = ["unstable-functions"] }
 hdi = { version = "0.8.0", features = ["unstable-functions"] }
 
 # Deps for Kitsune
-kitsune2 = { version = "0.5.1", default-features = false, features = [
+kitsune2 = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5", default-features = false, features = [
   "transport-iroh",
 ] }
-kitsune2_api = "0.5.1"
-kitsune2_bootstrap_srv = { version = "0.5.1", default-features = false }
-kitsune2_core = "0.5.1"
-kitsune2_gossip = "0.5.1"
-kitsune2_transport_iroh = { version = "0.5.1", default-features = false }
+kitsune2_api = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_bootstrap_srv = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5", default-features = false }
+kitsune2_core = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_gossip = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5" }
+kitsune2_transport_iroh = { git = "https://github.com/holochain/kitsune2", rev = "5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5", default-features = false }
 
 # Deps for Unyt
 # rave_engine = "0.3.2"


### PR DESCRIPTION
### Summary

Pins the Kitsune dependencies to commit `5e96fc82bed1b60b5c97ee20475e3fc716bd4dd5`. That commit waits for two peers to settle on one connection before sending their first gossip messages, which prevents the macOS failure tracked in #690. The unchanged failing test passed 10 consecutive times locally on macOS.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs. No Wind Tunnel code or public behavior documentation changed.
- [x] All new/edited/removed scenarios are reflected in the summary visualiser tool. No scenarios changed.
- [ ] I ran the Nomad CI workflow successfully on my branch. It is not required for this dependency-only test fix.
- [x] If this PR adds a new scenario, I have copied the new scenario checklist into this PR description. This PR does not add a scenario.

_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_